### PR TITLE
Please bump mt7668 package version, add reboot to android/fireos opti…

### DIFF
--- a/projects/Amlogic-ce/filesystem/usr/sbin/rebootfromnand
+++ b/projects/Amlogic-ce/filesystem/usr/sbin/rebootfromnand
@@ -4,5 +4,15 @@
 # Copyright (C) 2016-2018 kszaq (kszaquitto@gmail.com)
 # Copyright (C) 2019-present Team CoreELEC (https://coreelec.org)
 
-if /usr/sbin/fw_printenv whereToBootFrom > /dev/null 2>&1; then /usr/sbin/fw_setenv whereToBootFrom internal; fi
-/usr/sbin/fw_setenv bootfromnand 1
+DT_ID=$(cat /proc/device-tree/amlogic-dt-id 2>/dev/null | tr -d '\0')
+
+# Check if Fire TV Cube (g12brevb_raven_2g) 
+if [ "${DT_ID}" = "g12brevb_raven_2g" ]; then
+  /sbin/reboot quiescent
+else
+  if /usr/sbin/fw_printenv whereToBootFrom > /dev/null 2>&1; then
+    /usr/sbin/fw_setenv whereToBootFrom internal
+  fi
+  
+  /usr/sbin/fw_setenv bootfromnand 1
+fi

--- a/projects/Amlogic-ce/packages/linux-drivers/amlogic/mt7668-wifi-bt/package.mk
+++ b/projects/Amlogic-ce/packages/linux-drivers/amlogic/mt7668-wifi-bt/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-present Team CoreELEC (https://coreelec.org)
 
 PKG_NAME="mt7668-wifi-bt"
-PKG_VERSION="3439f2163ba308ce3380ba22f02e0c07d4884b33"
-PKG_SHA256="543f3cb467180fbb08ec9c453db85222c0b4c4aeef0db5d8623f3dfb789fd066"
+PKG_VERSION="c7137761ecd58595feda3a823795bc025d24d1c8"
+PKG_SHA256="8e318b76c16cf000d02ba79b809b3ce6869060e59404eb5c83ec8f71b8aeca51"
 PKG_ARCH="arm aarch64"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/noob404yt/mt7668-wifi-bt"


### PR DESCRIPTION
…on for Fire Cube (#1495)

* mt7668: bump package to c7137761 - BLE fix

* Amlogic-ce: add reboot to FireOS condition for FireTV Cube

FireTV Cube has no ENV, use repurposed reboot_reason quiescent to reboot to FireOS from CE.