### PR TITLE
Add dynamic splash handling for emulator loading

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -466,8 +466,14 @@ function init_app_video() {
 	[[ -z "$VIDEO_EMU" ]] && VIDEO_EMU=$(cat /tmp/EE_LASTVIDEO)
 
 	# Show splash screen if enabled
-	local SPL=$(get_ee_setting ee_splash.enabled)
-	[ "${SPL}" -eq "1" ] && ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}"
+        local SPL=$(get_ee_setting ee_splash.enabled)
+        if [ "${SPL}" -eq "1" ]; then
+                if [[ "${EE_SPLASH_DYNAMIC}" == "1" ]]; then
+                        ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}" loop
+                else
+                        ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}"
+                fi
+        fi
 
 	# Set the display video to that of the emulator setting.
 	[ ! -z "${VIDEO_EMU}" ] && ${TBASH} setres.sh "${VIDEO_EMU}" "${PLATFORM}" "${BASEROMNAME}" # set display

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -468,8 +468,13 @@ function init_app_video() {
 	# Show splash screen if enabled
         local SPL=$(get_ee_setting ee_splash.enabled)
         if [ "${SPL}" -eq "1" ]; then
-                if [[ "${EE_SPLASH_DYNAMIC}" == "1" ]]; then
-                        ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}" loop
+                local SPLASH_FLAG=""
+                if [[ "${EE_SPLASH_DYNAMIC}" == "1" && -f "tmp/Plibretro.p" ]]; then
+                        SPLASH_FLAG="loop"
+                fi
+
+                if [[ -n "${SPLASH_FLAG}" ]]; then
+                        ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}" "${SPLASH_FLAG}"
                 else
                         ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}"
                 fi
@@ -487,8 +492,11 @@ function end_app_video() {
 	# Return to default mode
 	${TBASH} setres.sh ${LAST_VIDEO}
 
-	# Show exit splash
-	${TBASH} show_splash.sh exit
+        # Ensure any pending splash player is stopped before showing the exit splash
+        ${TBASH} show_splash.sh stopplayer > /dev/null 2>&1
+
+        # Show exit splash
+        ${TBASH} show_splash.sh exit
 
 	rm /tmp/EE_LASTVIDEO
 }

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -453,9 +453,10 @@ function createMultidisc() {
 }
 
 function init_app_video() {
-	local PLATFORM=$1
-	local ROMNAME=$2
-	local BASEROMNAME=${ROMNAME##*/}
+        local PLATFORM=$1
+        local ROMNAME=$2
+        local BASEROMNAME=${ROMNAME##*/}
+        local LIBRETRO_MARKER="/tmp/Plibretro.p"
 
 	blank_buffer
 
@@ -469,7 +470,7 @@ function init_app_video() {
         local SPL=$(get_ee_setting ee_splash.enabled)
         if [ "${SPL}" -eq "1" ]; then
                 local SPLASH_FLAG=""
-                if [[ "${EE_SPLASH_DYNAMIC}" == "1" && -f "tmp/Plibretro.p" ]]; then
+                if [[ "${EE_SPLASH_DYNAMIC}" == "1" && -f "${LIBRETRO_MARKER}" ]]; then
                         SPLASH_FLAG="loop"
                 fi
 

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -75,6 +75,45 @@ set_kill_keys() {
     KILLSIGNAL=${2}
 }
 
+monitor_loading_output() {
+    local triggered=0
+    local timeout="${EE_SPLASH_TIMEOUT:-15}"
+    local pattern_default='Video @|Average audio buffer saturation|Set audio driver to|Environ SET_PIXEL_FORMAT'
+    local pattern="${EE_SPLASH_PATTERN:-$pattern_default}"
+    local timer_pid=""
+
+    if [[ -n "${timeout}" ]] && [[ "${timeout}" =~ ^[0-9]+$ ]] && [[ "${timeout}" -gt 0 ]]; then
+        (
+            sleep "${timeout}"
+            ${TBASH} show_splash.sh stopplayer >/dev/null 2>&1
+        ) &
+        timer_pid=$!
+    fi
+
+    while IFS= read -r line; do
+        if [[ ${triggered} -eq 0 ]] && [[ -n "${pattern}" ]]; then
+            if [[ "${line}" =~ ${pattern} ]]; then
+                triggered=1
+                if [[ -n "${timer_pid}" ]]; then
+                    kill "${timer_pid}" >/dev/null 2>&1
+                    wait "${timer_pid}" 2>/dev/null
+                    timer_pid=""
+                fi
+                ${TBASH} show_splash.sh stopplayer >/dev/null 2>&1
+            fi
+        fi
+    done
+
+    if [[ ${triggered} -eq 0 ]]; then
+        ${TBASH} show_splash.sh stopplayer >/dev/null 2>&1
+    fi
+
+    if [[ -n "${timer_pid}" ]]; then
+        kill "${timer_pid}" >/dev/null 2>&1
+        wait "${timer_pid}" 2>/dev/null
+    fi
+}
+
 # Extract the platform name from the arguments
 PLATFORM="${arguments##*-P}"  # read from -P onwards
 PLATFORM="${PLATFORM%% *}"  # until a space is found
@@ -98,6 +137,15 @@ if [[ "${CORE}" == *"_32b"* ]]; then
     RABIN="retroarch32"
 else
     BIT32="No"
+fi
+
+SPLASH_DYNAMIC=$(get_ee_setting ee_splash.dynamic_stop)
+if [[ "${SPLASH_DYNAMIC}" == "1" ]]; then
+    export EE_SPLASH_DYNAMIC="1"
+    EE_SPLASH_PATTERN=$(get_ee_setting ee_splash.dynamic_stop_pattern)
+    export EE_SPLASH_PATTERN
+    EE_SPLASH_TIMEOUT=$(get_ee_setting ee_splash.dynamic_timeout)
+    export EE_SPLASH_TIMEOUT
 fi
 
 if [[ "${EMULATOR}" = "libretro" ]]; then
@@ -154,7 +202,7 @@ CLOUD_PID=$!
 
 # Loading start
 rm "tmp/Plibretro.p"
-[[ "${LIBRETRO}" = "yes" ]] && touch "tmp/Plibretro.p" && emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}" & 
+[[ "${LIBRETRO}" = "yes" ]] && touch "tmp/Plibretro.p" && emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}" &
 [[ "${LIBRETRO}" != "yes" ]] && emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}"
 
 CONTROLLERCONFIG="${arguments#*--controllers=*}"
@@ -527,12 +575,26 @@ gptokeyb 1 ${KILLTHIS} ${VIRTUAL_KB} -killsignal ${KILLSIGNAL} &
 # Execute the command and try to output the results to the log file if it was not disabled.
 if [[ ${LOGEMU} == "Yes" ]]; then
    echo "Emulator Output is:" >> ${EMUELECLOG}
-   eval ${RUNTHIS} >> ${EMUELECLOG} 2>&1
-   ret_error=${?}
+   if [[ "${SPLASH_DYNAMIC}" == "1" && "${LIBRETRO}" == "yes" ]]; then
+        set -o pipefail
+        eval ${RUNTHIS} 2>&1 | tee >(monitor_loading_output) >> ${EMUELECLOG}
+        ret_error=${PIPESTATUS[0]}
+        set +o pipefail
+   else
+        eval ${RUNTHIS} >> ${EMUELECLOG} 2>&1
+        ret_error=${?}
+   fi
 else
    echo "Emulator log was dissabled" >> ${EMUELECLOG}
-   eval ${RUNTHIS} > /dev/null 2>&1
-   ret_error=${?}
+   if [[ "${SPLASH_DYNAMIC}" == "1" && "${LIBRETRO}" == "yes" ]]; then
+        set -o pipefail
+        eval ${RUNTHIS} 2>&1 | tee >(monitor_loading_output) > /dev/null
+        ret_error=${PIPESTATUS[0]}
+        set +o pipefail
+   else
+        eval ${RUNTHIS} > /dev/null 2>&1
+        ret_error=${?}
+   fi
 fi
 
 #blank_buffer

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -46,6 +46,7 @@ TBASH="/usr/bin/bash"
 RACONF="/storage/.config/retroarch/retroarch.cfg"
 NETPLAY="No"
 RABIN="retroarch"
+LIBRETRO_MARKER="/tmp/Plibretro.p"
 
 init_game
 
@@ -140,12 +141,15 @@ else
 fi
 
 SPLASH_DYNAMIC=$(get_ee_setting ee_splash.dynamic_stop)
-if [[ "${SPLASH_DYNAMIC}" == "1" ]]; then
+if [[ "${SPLASH_DYNAMIC}" == "1" && "${EMULATOR}" == "libretro" ]]; then
     export EE_SPLASH_DYNAMIC="1"
     EE_SPLASH_PATTERN=$(get_ee_setting ee_splash.dynamic_stop_pattern)
     export EE_SPLASH_PATTERN
     EE_SPLASH_TIMEOUT=$(get_ee_setting ee_splash.dynamic_timeout)
     export EE_SPLASH_TIMEOUT
+else
+    SPLASH_DYNAMIC="0"
+    unset EE_SPLASH_DYNAMIC EE_SPLASH_PATTERN EE_SPLASH_TIMEOUT
 fi
 
 if [[ "${EMULATOR}" = "libretro" ]]; then
@@ -201,8 +205,8 @@ CLOUD_SYNC=$(get_ee_setting "${PLATFORM}.cloudsave")
 CLOUD_PID=$!
 
 # Loading start
-rm "tmp/Plibretro.p"
-[[ "${LIBRETRO}" = "yes" ]] && touch "tmp/Plibretro.p" && emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}" &
+rm -f "${LIBRETRO_MARKER}"
+[[ "${LIBRETRO}" = "yes" ]] && touch "${LIBRETRO_MARKER}" && emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}" &
 [[ "${LIBRETRO}" != "yes" ]] && emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}"
 
 CONTROLLERCONFIG="${arguments#*--controllers=*}"
@@ -605,7 +609,10 @@ fi
         reset > /dev/console < /dev/null 2>&1
         
 # END loading
-[[ "${LIBRETRO}" = "yes" ]] && ${TBASH} show_splash.sh "stopplayer"
+if [[ "${LIBRETRO}" = "yes" ]]; then
+    ${TBASH} show_splash.sh "stopplayer"
+    rm -f "${LIBRETRO_MARKER}"
+fi
 
 emuelec-utils end_app_video
 

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -46,6 +46,8 @@ if [ "${ACTION_TYPE}" == "stopplayer" ] ; then
         rm -f "${SPLASH_MARKER}"
     fi
     killall "${PLAYER}" > /dev/null 2>&1
+    sleep 0.1
+    blank_buffer
     exit 0
 fi
 
@@ -227,13 +229,16 @@ if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]];
                     else
                         if [[ "${LIBRETRO_ACTIVE}" == "1" ]]; then
                             ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
+                        elif [[ "${ACTION_TYPE}" == "exit" ]]; then
+                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1
+                            blank_buffer
                         else
                             ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1 &
                             sleep 3
                         fi
                     fi
                 elif [ "${ACTION_TYPE}" == "exit" ]; then
-                    # Game over presentation, 3 seconds for images or video duration + 3 seconds.
+                    # Game over presentation, show static art for 3 seconds before clearing the buffer.
                     ${PLAYER} -fs ${SIZE} -vf scale=${SCALE}  "${SPLASH}" > /dev/null 2>&1 & sleep 3 && ACTION_TYPE="stopplayer"
                 else
                     if [[ "${LIBRETRO_ACTIVE}" == "1" ]]; then
@@ -270,6 +275,8 @@ if [ "${ACTION_TYPE}" == "stopplayer" ] ; then
         rm -f "${SPLASH_MARKER}"
     fi
     killall "${PLAYER}" > /dev/null 2>&1
+    sleep 0.1
+    blank_buffer
 fi
 
 # Wait for the duration specified by ee_splash.delay in emuelec.conf

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -24,6 +24,7 @@ VIDEOSPLASH="/usr/config/splash/emuelec_intro_1080p.mp4"
 RANDOMVIDEO="/storage/roms/splash/introvideos"
 DURATION="5"
 SPLASH_MARKER="/tmp/EE_SPLASH_ACTIVE"
+LIBRETRO_MARKER="/tmp/Plibretro.p"
 LOOP_MODE=0
 [[ "${EXTRA_FLAG}" == "loop" ]] && LOOP_MODE=1
 
@@ -42,11 +43,9 @@ echo ${PLATFORM} >> /emuelec/logs/logx.txt
 
 if [ "${ACTION_TYPE}" == "stopplayer" ] ; then
     if [[ -f "${SPLASH_MARKER}" ]]; then
-        killall "${PLAYER}" > /dev/null 2>&1
         rm -f "${SPLASH_MARKER}"
-    else
-        killall "${PLAYER}" > /dev/null 2>&1
     fi
+    killall "${PLAYER}" > /dev/null 2>&1
     exit 0
 fi
 
@@ -206,6 +205,14 @@ elif [[ "${PLAYER}" == "mpv" ]]; then
     PLAYER_LOOP_OPTS="--loop-file=inf --no-terminal"
 fi
 
+LIBRETRO_ACTIVE=0
+if [[ -f "${LIBRETRO_MARKER}" ]]; then
+    LIBRETRO_ACTIVE=1
+fi
+if [[ "${ACTION_TYPE}" == "exit" ]]; then
+    LIBRETRO_ACTIVE=0
+fi
+
 [[ "${ACTION_TYPE}" != "intro" ]] && VIDEO=0 || VIDEO=$(get_ee_setting ee_bootvideo.enabled)
 
 if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]]; then
@@ -214,27 +221,22 @@ if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]];
             ${PLAYER} "${SPLASH}" > /dev/null 2>&1
         else
                 if [[ "${EXTENSION_LOWER}" == "mp4" ]]; then
-                    if [[ -f "tmp/Plibretro.p" ]]; then
-                        if [[ "${LOOP_MODE}" == "1" && -n "${PLAYER_LOOP_OPTS}" ]]; then
-                            touch "${SPLASH_MARKER}"
-                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} ${PLAYER_LOOP_OPTS} "${SPLASH}" > /dev/null 2>&1
-                        else
-                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
-                        fi
+                    if [[ "${LOOP_MODE}" == "1" && -n "${PLAYER_LOOP_OPTS}" ]]; then
+                        touch "${SPLASH_MARKER}"
+                        ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} ${PLAYER_LOOP_OPTS} "${SPLASH}" > /dev/null 2>&1 &
                     else
-                        if [[ "${LOOP_MODE}" == "1" && -n "${PLAYER_LOOP_OPTS}" ]]; then
-                            touch "${SPLASH_MARKER}"
-                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} ${PLAYER_LOOP_OPTS} "${SPLASH}" > /dev/null 2>&1 &
+                        if [[ "${LIBRETRO_ACTIVE}" == "1" ]]; then
+                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
                         else
                             ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1 &
+                            sleep 3
                         fi
-                        [[ "${LOOP_MODE}" != "1" ]] && sleep 3
                     fi
                 elif [ "${ACTION_TYPE}" == "exit" ]; then
                     # Game over presentation, 3 seconds for images or video duration + 3 seconds.
                     ${PLAYER} -fs ${SIZE} -vf scale=${SCALE}  "${SPLASH}" > /dev/null 2>&1 & sleep 3 && ACTION_TYPE="stopplayer"
                 else
-                    if [[ -f "tmp/Plibretro.p" ]]; then
+                    if [[ "${LIBRETRO_ACTIVE}" == "1" ]]; then
                         ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
                     else
                         ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1 & sleep 3

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -13,6 +13,7 @@
 
 ACTION_TYPE="${1}"
 PLATFORM="${2}"
+EXTRA_FLAG="${4}"
 >/emuelec/logs/logx.txt
 echo ${PLATFORM} >> /emuelec/logs/logx.txt
 
@@ -22,6 +23,9 @@ DEFAULTSPLASH="/storage/.config/splash/splash-1080.png"
 VIDEOSPLASH="/usr/config/splash/emuelec_intro_1080p.mp4"
 RANDOMVIDEO="/storage/roms/splash/introvideos"
 DURATION="5"
+SPLASH_MARKER="/tmp/EE_SPLASH_ACTIVE"
+LOOP_MODE=0
+[[ "${EXTRA_FLAG}" == "loop" ]] && LOOP_MODE=1
 
 if [ -f "/storage/roms/splash/intro.mp4" ]; then
     VIDEOSPLASH="/storage/roms/splash/intro.mp4"
@@ -35,6 +39,16 @@ fi
 PLATFORM=${PLATFORM,,}
 PLAYER="ffplay"
 echo ${PLATFORM} >> /emuelec/logs/logx.txt
+
+if [ "${ACTION_TYPE}" == "stopplayer" ] ; then
+    if [[ -f "${SPLASH_MARKER}" ]]; then
+        killall "${PLAYER}" > /dev/null 2>&1
+        rm -f "${SPLASH_MARKER}"
+    else
+        killall "${PLAYER}" > /dev/null 2>&1
+    fi
+    exit 0
+fi
 
 case ${PLATFORM} in
  "arcade"|"fba"|"fbn"|"neogeo"|"mame"|cps*)
@@ -184,6 +198,13 @@ declare -a RES=( ${MODE} )
 SIZE=" -x ${RES[0]} -y ${RES[1]}"
 SCALE="${RES[0]}:${RES[1]}"
 EXTENSION="${SPLASH##*.}"
+EXTENSION_LOWER=$(echo "${EXTENSION}" | tr '[:upper:]' '[:lower:]')
+PLAYER_LOOP_OPTS=""
+if [[ "${PLAYER}" == "ffplay" ]]; then
+    PLAYER_LOOP_OPTS="-loop 0"
+elif [[ "${PLAYER}" == "mpv" ]]; then
+    PLAYER_LOOP_OPTS="--loop-file=inf --no-terminal"
+fi
 
 [[ "${ACTION_TYPE}" != "intro" ]] && VIDEO=0 || VIDEO=$(get_ee_setting ee_bootvideo.enabled)
 
@@ -192,24 +213,35 @@ if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]];
         if [ "${SS_DEVICE}" == 1 ]; then
             ${PLAYER} "${SPLASH}" > /dev/null 2>&1
         else
-               if [[ "$EXTENSION" == "mp4" || "$EXTENSION" == "MP4" ]]; then
+                if [[ "${EXTENSION_LOWER}" == "mp4" ]]; then
                     if [[ -f "tmp/Plibretro.p" ]]; then
-                         ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
-                     else
-                         ${PLAYER} -fs -autoexit ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
+                        if [[ "${LOOP_MODE}" == "1" && -n "${PLAYER_LOOP_OPTS}" ]]; then
+                            touch "${SPLASH_MARKER}"
+                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} ${PLAYER_LOOP_OPTS} "${SPLASH}" > /dev/null 2>&1
+                        else
+                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
+                        fi
+                    else
+                        if [[ "${LOOP_MODE}" == "1" && -n "${PLAYER_LOOP_OPTS}" ]]; then
+                            touch "${SPLASH_MARKER}"
+                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} ${PLAYER_LOOP_OPTS} "${SPLASH}" > /dev/null 2>&1 &
+                        else
+                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1 &
+                        fi
+                        [[ "${LOOP_MODE}" != "1" ]] && sleep 3
                     fi
                 elif [ "${ACTION_TYPE}" == "exit" ]; then
-                # Game over presentation, 3 seconds for images or video duration + 3 seconds.
-                ${PLAYER} -fs ${SIZE} -vf scale=${SCALE}  "${SPLASH}" > /dev/null 2>&1 & sleep 3 && ACTION_TYPE="stopplayer"
+                    # Game over presentation, 3 seconds for images or video duration + 3 seconds.
+                    ${PLAYER} -fs ${SIZE} -vf scale=${SCALE}  "${SPLASH}" > /dev/null 2>&1 & sleep 3 && ACTION_TYPE="stopplayer"
                 else
-                   if [[ -f "tmp/Plibretro.p" ]]; then
-                     ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
-                   else
-                     ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1 & sleep 3 
-                   fi
+                    if [[ -f "tmp/Plibretro.p" ]]; then
+                        ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
+                    else
+                        ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1 & sleep 3
+                    fi
                 fi
             fi
-        fi 
+        fi
 else
     # Display intro video
     RND=$(get_ee_setting "ee_randombootvideo.enabled" == "1")
@@ -230,9 +262,12 @@ else
     # [ -e /storage/.config/asound.confs ] && mv /storage/.config/asound.confs /storage/.config/asound.conf
 fi
 
+# Handle deferred stop requests (e.g. exit splash sleep)
 if [ "${ACTION_TYPE}" == "stopplayer" ] ; then
-    killall "${PLAYER}"
-    #blank_buffer
+    if [[ -f "${SPLASH_MARKER}" ]]; then
+        rm -f "${SPLASH_MARKER}"
+    fi
+    killall "${PLAYER}" > /dev/null 2>&1
 fi
 
 # Wait for the duration specified by ee_splash.delay in emuelec.conf

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -227,14 +227,13 @@ if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]];
                         touch "${SPLASH_MARKER}"
                         ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} ${PLAYER_LOOP_OPTS} "${SPLASH}" > /dev/null 2>&1 &
                     else
-                        if [[ "${LIBRETRO_ACTIVE}" == "1" ]]; then
-                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
-                        elif [[ "${ACTION_TYPE}" == "exit" ]]; then
+                        if [[ "${ACTION_TYPE}" == "exit" ]]; then
                             ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1
                             blank_buffer
+                        elif [[ "${LIBRETRO_ACTIVE}" == "1" ]]; then
+                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
                         else
-                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1 &
-                            sleep 3
+                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1
                         fi
                     fi
                 elif [ "${ACTION_TYPE}" == "exit" ]; then


### PR DESCRIPTION
## Summary
- loop the game loading splash when dynamic splash handling is enabled
- monitor emulator output to close the splash as soon as the core becomes ready
- expose configuration hooks for timeout/pattern control while keeping legacy behaviour by default

## Testing
- bash -n packages/sx05re/emuelec/bin/show_splash.sh
- bash -n packages/sx05re/emuelec/bin/emuelecRunEmu.sh
- bash -n packages/sx05re/emuelec/bin/emuelec-utils

------
https://chatgpt.com/codex/tasks/task_e_68ce35705f748320b9906f3e5bbbd29f