### PR TITLE
Auto-stop standalone splashes without touching launchers

### DIFF
--- a/packages/sx05re/emuelec/bin/ee_splash_wrapper.sh
+++ b/packages/sx05re/emuelec/bin/ee_splash_wrapper.sh
@@ -25,6 +25,37 @@ is_shell_like() {
     return 1
 }
 
+has_non_shell_descendant() {
+    local root_pid=$1
+    local -A seen=()
+    local queue=("${root_pid}")
+    local idx=0
+
+    while (( idx < ${#queue[@]} )); do
+        local current_pid=${queue[idx]}
+        ((idx++))
+
+        while IFS= read -r child_pid; do
+            child_pid=${child_pid//[[:space:]]/}
+            [[ -z "${child_pid}" ]] && continue
+            if [[ ${seen[${child_pid}]+_} ]]; then
+                continue
+            fi
+            seen["${child_pid}"]=1
+
+            local child_exe
+            child_exe=$(readlink -f "/proc/${child_pid}/exe" 2>/dev/null || true)
+            if [[ -n "${child_exe}" ]] && ! is_shell_like "${child_exe}"; then
+                return 0
+            fi
+
+            queue+=("${child_pid}")
+        done < <(ps -o pid= --ppid "${current_pid}" 2>/dev/null)
+    done
+
+    return 1
+}
+
 monitor_pid() {
     local target_pid=$1
     local timeout="${EE_SPLASH_TIMEOUT:-15}"
@@ -38,16 +69,10 @@ monitor_pid() {
             return
         fi
 
-        local children
-        children=$(cat "/proc/${target_pid}/task/${target_pid}/children" 2>/dev/null || true)
-        for child in ${children}; do
-            local child_exe
-            child_exe=$(readlink -f "/proc/${child}/exe" 2>/dev/null || true)
-            if [[ -n "${child_exe}" ]] && ! is_shell_like "${child_exe}"; then
-                stop_splash
-                return
-            fi
-        done
+        if has_non_shell_descendant "${target_pid}"; then
+            stop_splash
+            return
+        fi
 
         if [[ -n "${timeout}" && "${timeout}" =~ ^[0-9]+$ ]]; then
             local now=$(date +%s)

--- a/packages/sx05re/emuelec/bin/ee_splash_wrapper.sh
+++ b/packages/sx05re/emuelec/bin/ee_splash_wrapper.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. /etc/profile
+
+STOPPED=0
+
+stop_splash() {
+    if [[ ${STOPPED} -eq 0 ]]; then
+        STOPPED=1
+        "${TBASH:-/usr/bin/bash}" show_splash.sh stopplayer >/dev/null 2>&1 || true
+    fi
+}
+
+is_shell_like() {
+    case "$1" in
+        ""|"/bin/bash"|"/usr/bin/bash"|"/bin/sh"|"/usr/bin/sh"|"/usr/bin/env"|"/bin/busybox"|"/usr/bin/busybox")
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+monitor_pid() {
+    local target_pid=$1
+    local timeout="${EE_SPLASH_TIMEOUT:-15}"
+    local start_ts=$(date +%s)
+
+    while kill -0 "${target_pid}" 2>/dev/null; do
+        local exe
+        exe=$(readlink -f "/proc/${target_pid}/exe" 2>/dev/null || true)
+        if [[ -n "${exe}" ]] && ! is_shell_like "${exe}"; then
+            stop_splash
+            return
+        fi
+
+        local children
+        children=$(cat "/proc/${target_pid}/task/${target_pid}/children" 2>/dev/null || true)
+        for child in ${children}; do
+            local child_exe
+            child_exe=$(readlink -f "/proc/${child}/exe" 2>/dev/null || true)
+            if [[ -n "${child_exe}" ]] && ! is_shell_like "${child_exe}"; then
+                stop_splash
+                return
+            fi
+        done
+
+        if [[ -n "${timeout}" && "${timeout}" =~ ^[0-9]+$ ]]; then
+            local now=$(date +%s)
+            if (( now - start_ts >= timeout )); then
+                stop_splash
+                return
+            fi
+        fi
+
+        sleep 0.1
+    done
+
+    stop_splash
+}
+
+if [[ "${EE_SPLASH_DYNAMIC:-0}" != "1" || "${EE_SPLASH_STANDALONE:-0}" != "1" ]]; then
+    exec "$@"
+fi
+
+"$@" &
+cmd_pid=$!
+monitor_pid "${cmd_pid}" &
+watcher_pid=$!
+wait "${cmd_pid}"
+status=$?
+wait "${watcher_pid}" 2>/dev/null || true
+exit ${status}

--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -453,9 +453,10 @@ function createMultidisc() {
 }
 
 function init_app_video() {
-	local PLATFORM=$1
-	local ROMNAME=$2
-	local BASEROMNAME=${ROMNAME##*/}
+        local PLATFORM=$1
+        local ROMNAME=$2
+        local BASEROMNAME=${ROMNAME##*/}
+        local LIBRETRO_MARKER="/tmp/Plibretro.p"
 
 	blank_buffer
 
@@ -466,8 +467,21 @@ function init_app_video() {
 	[[ -z "$VIDEO_EMU" ]] && VIDEO_EMU=$(cat /tmp/EE_LASTVIDEO)
 
 	# Show splash screen if enabled
-	local SPL=$(get_ee_setting ee_splash.enabled)
-	[ "${SPL}" -eq "1" ] && ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}"
+        local SPL=$(get_ee_setting ee_splash.enabled)
+        if [ "${SPL}" -eq "1" ]; then
+                local SPLASH_FLAG=""
+                if [[ "${EE_SPLASH_DYNAMIC}" == "1" ]]; then
+                        if [[ -f "${LIBRETRO_MARKER}" || "${EE_SPLASH_STANDALONE}" == "1" ]]; then
+                                SPLASH_FLAG="loop"
+                        fi
+                fi
+
+                if [[ -n "${SPLASH_FLAG}" ]]; then
+                        ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}" "${SPLASH_FLAG}"
+                else
+                        ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}"
+                fi
+        fi
 
 	# Set the display video to that of the emulator setting.
 	[ ! -z "${VIDEO_EMU}" ] && ${TBASH} setres.sh "${VIDEO_EMU}" "${PLATFORM}" "${BASEROMNAME}" # set display
@@ -481,8 +495,11 @@ function end_app_video() {
 	# Return to default mode
 	${TBASH} setres.sh ${LAST_VIDEO}
 
-	# Show exit splash
-	${TBASH} show_splash.sh exit
+        # Ensure any pending splash player is stopped before showing the exit splash
+        ${TBASH} show_splash.sh stopplayer > /dev/null 2>&1
+
+        # Show exit splash
+        ${TBASH} show_splash.sh exit
 
 	rm /tmp/EE_LASTVIDEO
 }

--- a/packages/sx05re/emuelec/bin/emuelecRunApp.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunApp.sh
@@ -9,6 +9,28 @@
 
 arguments="$@"
 
+# Configure dynamic splash handling before starting the splash
+SPLASH_DYNAMIC_RAW=$(get_ee_setting ee_splash.dynamic_stop)
+case "${SPLASH_DYNAMIC_RAW,,}" in
+    1|true|yes|on|enabled)
+        SPLASH_DYNAMIC="1"
+        ;;
+    *)
+        SPLASH_DYNAMIC="0"
+        ;;
+esac
+
+if [[ "${SPLASH_DYNAMIC}" == "1" ]]; then
+    export EE_SPLASH_DYNAMIC="1"
+    EE_SPLASH_PATTERN=$(get_ee_setting ee_splash.dynamic_stop_pattern)
+    export EE_SPLASH_PATTERN
+    EE_SPLASH_TIMEOUT=$(get_ee_setting ee_splash.dynamic_timeout)
+    export EE_SPLASH_TIMEOUT
+    export EE_SPLASH_STANDALONE="1"
+else
+    unset EE_SPLASH_DYNAMIC EE_SPLASH_PATTERN EE_SPLASH_TIMEOUT EE_SPLASH_STANDALONE
+fi
+
 # Extract the platform name from the arguments
 PLATFORM="${arguments##*-P}"  # read from -P onwards
 PLATFORM="${PLATFORM%% *}"  # until a space is found
@@ -18,7 +40,11 @@ ROMNAME="${1}"
 init_game
 emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}"
 
-"$@"
+if [[ "${SPLASH_DYNAMIC}" == "1" ]]; then
+    ee_splash_wrapper.sh "$@"
+else
+    "$@"
+fi
 
 emuelec-utils end_app_video
 end_game

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -140,7 +140,16 @@ else
     BIT32="No"
 fi
 
-SPLASH_DYNAMIC=$(get_ee_setting ee_splash.dynamic_stop)
+SPLASH_DYNAMIC_RAW=$(get_ee_setting ee_splash.dynamic_stop)
+case "${SPLASH_DYNAMIC_RAW,,}" in
+    1|true|yes|on|enabled)
+        SPLASH_DYNAMIC="1"
+        ;;
+    *)
+        SPLASH_DYNAMIC="0"
+        ;;
+esac
+
 if [[ "${SPLASH_DYNAMIC}" == "1" ]]; then
     export EE_SPLASH_DYNAMIC="1"
     EE_SPLASH_PATTERN=$(get_ee_setting ee_splash.dynamic_stop_pattern)

--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -46,6 +46,7 @@ TBASH="/usr/bin/bash"
 RACONF="/storage/.config/retroarch/retroarch.cfg"
 NETPLAY="No"
 RABIN="retroarch"
+LIBRETRO_MARKER="/tmp/Plibretro.p"
 
 init_game
 
@@ -75,6 +76,45 @@ set_kill_keys() {
     KILLSIGNAL=${2}
 }
 
+monitor_loading_output() {
+    local triggered=0
+    local timeout="${EE_SPLASH_TIMEOUT:-15}"
+    local pattern_default='EE_SPLASH_READY|Video @|Average audio buffer saturation|Set audio driver to|Environ SET_PIXEL_FORMAT'
+    local pattern="${EE_SPLASH_PATTERN:-$pattern_default}"
+    local timer_pid=""
+
+    if [[ -n "${timeout}" ]] && [[ "${timeout}" =~ ^[0-9]+$ ]] && [[ "${timeout}" -gt 0 ]]; then
+        (
+            sleep "${timeout}"
+            ${TBASH} show_splash.sh stopplayer >/dev/null 2>&1
+        ) &
+        timer_pid=$!
+    fi
+
+    while IFS= read -r line; do
+        if [[ ${triggered} -eq 0 ]] && [[ -n "${pattern}" ]]; then
+            if [[ "${line}" =~ ${pattern} ]]; then
+                triggered=1
+                if [[ -n "${timer_pid}" ]]; then
+                    kill "${timer_pid}" >/dev/null 2>&1
+                    wait "${timer_pid}" 2>/dev/null
+                    timer_pid=""
+                fi
+                ${TBASH} show_splash.sh stopplayer >/dev/null 2>&1
+            fi
+        fi
+    done
+
+    if [[ ${triggered} -eq 0 ]]; then
+        ${TBASH} show_splash.sh stopplayer >/dev/null 2>&1
+    fi
+
+    if [[ -n "${timer_pid}" ]]; then
+        kill "${timer_pid}" >/dev/null 2>&1
+        wait "${timer_pid}" 2>/dev/null
+    fi
+}
+
 # Extract the platform name from the arguments
 PLATFORM="${arguments##*-P}"  # read from -P onwards
 PLATFORM="${PLATFORM%% *}"  # until a space is found
@@ -98,6 +138,25 @@ if [[ "${CORE}" == *"_32b"* ]]; then
     RABIN="retroarch32"
 else
     BIT32="No"
+fi
+
+SPLASH_DYNAMIC=$(get_ee_setting ee_splash.dynamic_stop)
+if [[ "${SPLASH_DYNAMIC}" == "1" ]]; then
+    export EE_SPLASH_DYNAMIC="1"
+    EE_SPLASH_PATTERN=$(get_ee_setting ee_splash.dynamic_stop_pattern)
+    export EE_SPLASH_PATTERN
+    EE_SPLASH_TIMEOUT=$(get_ee_setting ee_splash.dynamic_timeout)
+    export EE_SPLASH_TIMEOUT
+    if [[ "${EMULATOR}" == "libretro" ]]; then
+        unset EE_SPLASH_STANDALONE
+    elif [[ "${EMULATOR}" == "retrorun" ]]; then
+        unset EE_SPLASH_STANDALONE
+    else
+        export EE_SPLASH_STANDALONE="1"
+    fi
+else
+    SPLASH_DYNAMIC="0"
+    unset EE_SPLASH_DYNAMIC EE_SPLASH_PATTERN EE_SPLASH_TIMEOUT EE_SPLASH_STANDALONE
 fi
 
 if [[ "${EMULATOR}" = "libretro" ]]; then
@@ -153,8 +212,8 @@ CLOUD_SYNC=$(get_ee_setting "${PLATFORM}.cloudsave")
 CLOUD_PID=$!
 
 # Loading start
-rm "tmp/Plibretro.p"
-[[ "${LIBRETRO}" = "yes" ]] && touch "tmp/Plibretro.p" && emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}" & 
+rm -f "${LIBRETRO_MARKER}"
+[[ "${LIBRETRO}" = "yes" ]] && touch "${LIBRETRO_MARKER}" && emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}" &
 [[ "${LIBRETRO}" != "yes" ]] && emuelec-utils init_app_video "${PLATFORM}" "${ROMNAME}"
 
 CONTROLLERCONFIG="${arguments#*--controllers=*}"
@@ -524,15 +583,33 @@ gptokeyb 1 ${KILLTHIS} ${VIRTUAL_KB} -killsignal ${KILLSIGNAL} &
 
 [[ "${CLOUD_SYNC}" == "1" ]] && wait ${CLOUD_PID}
 
+if [[ "${SPLASH_DYNAMIC}" == "1" && "${LIBRETRO}" != "yes" && "${EE_SPLASH_STANDALONE:-0}" == "1" ]]; then
+    RUNTHIS="ee_splash_wrapper.sh ${RUNTHIS}"
+fi
+
 # Execute the command and try to output the results to the log file if it was not disabled.
 if [[ ${LOGEMU} == "Yes" ]]; then
    echo "Emulator Output is:" >> ${EMUELECLOG}
-   eval ${RUNTHIS} >> ${EMUELECLOG} 2>&1
-   ret_error=${?}
+   if [[ "${SPLASH_DYNAMIC}" == "1" && "${LIBRETRO}" == "yes" ]]; then
+        set -o pipefail
+        eval ${RUNTHIS} 2>&1 | tee >(monitor_loading_output) >> ${EMUELECLOG}
+        ret_error=${PIPESTATUS[0]}
+        set +o pipefail
+   else
+        eval ${RUNTHIS} >> ${EMUELECLOG} 2>&1
+        ret_error=${?}
+   fi
 else
    echo "Emulator log was dissabled" >> ${EMUELECLOG}
-   eval ${RUNTHIS} > /dev/null 2>&1
-   ret_error=${?}
+   if [[ "${SPLASH_DYNAMIC}" == "1" && "${LIBRETRO}" == "yes" ]]; then
+        set -o pipefail
+        eval ${RUNTHIS} 2>&1 | tee >(monitor_loading_output) > /dev/null
+        ret_error=${PIPESTATUS[0]}
+        set +o pipefail
+   else
+        eval ${RUNTHIS} > /dev/null 2>&1
+        ret_error=${?}
+   fi
 fi
 
 #blank_buffer
@@ -543,7 +620,10 @@ fi
         reset > /dev/console < /dev/null 2>&1
         
 # END loading
-[[ "${LIBRETRO}" = "yes" ]] && ${TBASH} show_splash.sh "stopplayer"
+if [[ "${LIBRETRO}" = "yes" ]]; then
+    ${TBASH} show_splash.sh "stopplayer"
+    rm -f "${LIBRETRO_MARKER}"
+fi
 
 emuelec-utils end_app_video
 

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -13,6 +13,7 @@
 
 ACTION_TYPE="${1}"
 PLATFORM="${2}"
+EXTRA_FLAG="${4}"
 >/emuelec/logs/logx.txt
 echo ${PLATFORM} >> /emuelec/logs/logx.txt
 
@@ -22,6 +23,10 @@ DEFAULTSPLASH="/storage/.config/splash/splash-1080.png"
 VIDEOSPLASH="/usr/config/splash/emuelec_intro_1080p.mp4"
 RANDOMVIDEO="/storage/roms/splash/introvideos"
 DURATION="5"
+SPLASH_MARKER="/tmp/EE_SPLASH_ACTIVE"
+LIBRETRO_MARKER="/tmp/Plibretro.p"
+LOOP_MODE=0
+[[ "${EXTRA_FLAG}" == "loop" ]] && LOOP_MODE=1
 
 if [ -f "/storage/roms/splash/intro.mp4" ]; then
     VIDEOSPLASH="/storage/roms/splash/intro.mp4"
@@ -35,6 +40,16 @@ fi
 PLATFORM=${PLATFORM,,}
 PLAYER="ffplay"
 echo ${PLATFORM} >> /emuelec/logs/logx.txt
+
+if [ "${ACTION_TYPE}" == "stopplayer" ] ; then
+    if [[ -f "${SPLASH_MARKER}" ]]; then
+        rm -f "${SPLASH_MARKER}"
+    fi
+    killall "${PLAYER}" > /dev/null 2>&1
+    sleep 0.1
+    blank_buffer
+    exit 0
+fi
 
 case ${PLATFORM} in
  "arcade"|"fba"|"fbn"|"neogeo"|"mame"|cps*)
@@ -184,6 +199,21 @@ declare -a RES=( ${MODE} )
 SIZE=" -x ${RES[0]} -y ${RES[1]}"
 SCALE="${RES[0]}:${RES[1]}"
 EXTENSION="${SPLASH##*.}"
+EXTENSION_LOWER=$(echo "${EXTENSION}" | tr '[:upper:]' '[:lower:]')
+PLAYER_LOOP_OPTS=""
+if [[ "${PLAYER}" == "ffplay" ]]; then
+    PLAYER_LOOP_OPTS="-loop 0"
+elif [[ "${PLAYER}" == "mpv" ]]; then
+    PLAYER_LOOP_OPTS="--loop-file=inf --no-terminal"
+fi
+
+LIBRETRO_ACTIVE=0
+if [[ -f "${LIBRETRO_MARKER}" ]]; then
+    LIBRETRO_ACTIVE=1
+fi
+if [[ "${ACTION_TYPE}" == "exit" ]]; then
+    LIBRETRO_ACTIVE=0
+fi
 
 [[ "${ACTION_TYPE}" != "intro" ]] && VIDEO=0 || VIDEO=$(get_ee_setting ee_bootvideo.enabled)
 
@@ -192,24 +222,32 @@ if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]];
         if [ "${SS_DEVICE}" == 1 ]; then
             ${PLAYER} "${SPLASH}" > /dev/null 2>&1
         else
-               if [[ "$EXTENSION" == "mp4" || "$EXTENSION" == "MP4" ]]; then
-                    if [[ -f "tmp/Plibretro.p" ]]; then
-                         ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
-                     else
-                         ${PLAYER} -fs -autoexit ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
+                if [[ "${EXTENSION_LOWER}" == "mp4" ]]; then
+                    if [[ "${LOOP_MODE}" == "1" && -n "${PLAYER_LOOP_OPTS}" ]]; then
+                        touch "${SPLASH_MARKER}"
+                        ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} ${PLAYER_LOOP_OPTS} "${SPLASH}" > /dev/null 2>&1 &
+                    else
+                        if [[ "${ACTION_TYPE}" == "exit" ]]; then
+                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1
+                            blank_buffer
+                        elif [[ "${LIBRETRO_ACTIVE}" == "1" ]]; then
+                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
+                        else
+                            ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1
+                        fi
                     fi
                 elif [ "${ACTION_TYPE}" == "exit" ]; then
-                # Game over presentation, 3 seconds for images or video duration + 3 seconds.
-                ${PLAYER} -fs ${SIZE} -vf scale=${SCALE}  "${SPLASH}" > /dev/null 2>&1 & sleep 3 && ACTION_TYPE="stopplayer"
+                    # Game over presentation, show static art for 3 seconds before clearing the buffer.
+                    ${PLAYER} -fs ${SIZE} -vf scale=${SCALE}  "${SPLASH}" > /dev/null 2>&1 & sleep 3 && ACTION_TYPE="stopplayer"
                 else
-                   if [[ -f "tmp/Plibretro.p" ]]; then
-                     ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
-                   else
-                     ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1 & sleep 3 
-                   fi
+                    if [[ "${LIBRETRO_ACTIVE}" == "1" ]]; then
+                        ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} "${SPLASH}" > /dev/null 2>&1
+                    else
+                        ${PLAYER} -fs ${SIZE} -vf scale=${SCALE} -autoexit "${SPLASH}" > /dev/null 2>&1 & sleep 3
+                    fi
                 fi
             fi
-        fi 
+        fi
 else
     # Display intro video
     RND=$(get_ee_setting "ee_randombootvideo.enabled" == "1")
@@ -230,9 +268,14 @@ else
     # [ -e /storage/.config/asound.confs ] && mv /storage/.config/asound.confs /storage/.config/asound.conf
 fi
 
+# Handle deferred stop requests (e.g. exit splash sleep)
 if [ "${ACTION_TYPE}" == "stopplayer" ] ; then
-    killall "${PLAYER}"
-    #blank_buffer
+    if [[ -f "${SPLASH_MARKER}" ]]; then
+        rm -f "${SPLASH_MARKER}"
+    fi
+    killall "${PLAYER}" > /dev/null 2>&1
+    sleep 0.1
+    blank_buffer
 fi
 
 # Wait for the duration specified by ee_splash.delay in emuelec.conf


### PR DESCRIPTION
## Summary
- add an ee_splash_wrapper helper that watches the launched PID tree and stops the splash loop once a non-shell process is running
- wrap standalone executions in emuelecRunEmu with the new helper while limiting dynamic log monitoring to libretro launches
- remove the old notify_splash_ready hook and restore standalone launcher scripts to their prior form

## Testing
- for f in $(git diff --cached --name-only); do bash -n "$f"; done


------
https://chatgpt.com/codex/tasks/task_e_68ce35705f748320b9906f3e5bbbd29f