### PR TITLE
Stop loading splashes when emulators start

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
+++ b/packages/sx05re/emuelec/bin/emuelecRunEmu.sh
@@ -524,12 +524,21 @@ gptokeyb 1 ${KILLTHIS} ${VIRTUAL_KB} -killsignal ${KILLSIGNAL} &
 # Execute the command and try to output the results to the log file if it was not disabled.
 if [[ ${LOGEMU} == "Yes" ]]; then
    echo "Emulator Output is:" >> ${EMUELECLOG}
-   eval ${RUNTHIS} >> ${EMUELECLOG} 2>&1
-   ret_error=${?}
+   eval ${RUNTHIS} >> ${EMUELECLOG} 2>&1 &
+   EMULATOR_PID=$!
 else
    echo "Emulator log was dissabled" >> ${EMUELECLOG}
-   eval ${RUNTHIS} > /dev/null 2>&1
+   eval ${RUNTHIS} > /dev/null 2>&1 &
+   EMULATOR_PID=$!
+fi
+
+${TBASH} show_splash.sh "stopplayer"
+
+if [[ -n "${EMULATOR_PID}" ]]; then
+   wait "${EMULATOR_PID}"
    ret_error=${?}
+else
+   ret_error=1
 fi
 
 #blank_buffer
@@ -540,7 +549,7 @@ fi
         reset > /dev/console < /dev/null 2>&1
 
 # END loading
-[[ "${LIBRETRO}" = "yes" ]] && ${TBASH} show_splash.sh "stopplayer"
+${TBASH} show_splash.sh "stopplayer"
 
 emuelec-utils end_app_video
 

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -20,22 +20,33 @@ PLATFORM="${2}"
 SPLASH_PID_FILE="/tmp/ee_splash_player.pid"
 
 stop_splash_player() {
-  local pid
+  local pid pgid
 
   [ ! -f "${SPLASH_PID_FILE}" ] && return 0
 
   while read -r pid; do
     [[ -z "${pid}" ]] && continue
     if kill -0 "${pid}" 2>/dev/null; then
-      kill -TERM -"${pid}" 2>/dev/null || kill -TERM "${pid}" 2>/dev/null
+      pgid="$(ps -o pgid= -p "${pid}" 2>/dev/null | tr -d ' ')"
+      if [[ -n "${pgid}" ]] && [[ "${pgid}" == "${pid}" ]]; then
+        kill -TERM -"${pgid}" 2>/dev/null
+      fi
+      kill -TERM "${pid}" 2>/dev/null
       sleep 0.2
       if kill -0 "${pid}" 2>/dev/null; then
-        kill -KILL -"${pid}" 2>/dev/null || kill -KILL "${pid}" 2>/dev/null
+        if [[ -n "${pgid}" ]] && [[ "${pgid}" == "${pid}" ]]; then
+          kill -KILL -"${pgid}" 2>/dev/null
+        fi
+        kill -KILL "${pid}" 2>/dev/null
       fi
     fi
   done < "${SPLASH_PID_FILE}"
 
   rm -f "${SPLASH_PID_FILE}"
+
+  if type blank_buffer >/dev/null 2>&1; then
+    blank_buffer >/dev/null 2>&1
+  fi
 }
 
 record_splash_pid() {
@@ -48,11 +59,7 @@ run_player_command() {
   shift
 
   if [[ "${background_mode}" -eq 1 ]]; then
-    if command -v setsid >/dev/null 2>&1; then
-      setsid "$@" >/dev/null 2>&1 &
-    else
-      "$@" >/dev/null 2>&1 &
-    fi
+    nohup "$@" >/dev/null 2>&1 &
     record_splash_pid "$!"
   else
     "$@" >/dev/null 2>&1

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -20,25 +20,49 @@ PLATFORM="${2}"
 SPLASH_PID_FILE="/tmp/ee_splash_player.pid"
 
 stop_splash_player() {
-  local pid pgid
+  local pid pgid attempt
 
-  [ ! -f "${SPLASH_PID_FILE}" ] && return 0
+  if [[ ! -f "${SPLASH_PID_FILE}" ]]; then
+    if type blank_buffer >/dev/null 2>&1; then
+      blank_buffer >/dev/null 2>&1
+    fi
+    return 0
+  fi
 
   while read -r pid; do
     [[ -z "${pid}" ]] && continue
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      continue
+    fi
+
+    pgid="$(ps -o pgid= -p "${pid}" 2>/dev/null | tr -d ' ')"
+
+    if [[ -n "${pgid}" ]] && [[ "${pgid}" =~ ^[0-9]+$ ]]; then
+      kill -TERM -"${pgid}" 2>/dev/null
+    fi
+    kill -TERM "${pid}" 2>/dev/null
+
+    attempt=0
+    while kill -0 "${pid}" 2>/dev/null && (( attempt < 20 )); do
+      sleep 0.05
+      attempt=$((attempt + 1))
+    done
+
     if kill -0 "${pid}" 2>/dev/null; then
-      pgid="$(ps -o pgid= -p "${pid}" 2>/dev/null | tr -d ' ')"
-      if [[ -n "${pgid}" ]] && [[ "${pgid}" == "${pid}" ]]; then
-        kill -TERM -"${pgid}" 2>/dev/null
+      if [[ -n "${pgid}" ]] && [[ "${pgid}" =~ ^[0-9]+$ ]]; then
+        kill -KILL -"${pgid}" 2>/dev/null
       fi
-      kill -TERM "${pid}" 2>/dev/null
-      sleep 0.2
-      if kill -0 "${pid}" 2>/dev/null; then
-        if [[ -n "${pgid}" ]] && [[ "${pgid}" == "${pid}" ]]; then
-          kill -KILL -"${pgid}" 2>/dev/null
-        fi
-        kill -KILL "${pid}" 2>/dev/null
-      fi
+      kill -KILL "${pid}" 2>/dev/null
+    fi
+
+    attempt=0
+    while kill -0 "${pid}" 2>/dev/null && (( attempt < 40 )); do
+      sleep 0.05
+      attempt=$((attempt + 1))
+    done
+
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      wait "${pid}" 2>/dev/null
     fi
   done < "${SPLASH_PID_FILE}"
 

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -55,18 +55,22 @@ run_player_command() {
 
   if [[ "${background_mode}" -eq 1 ]]; then
     local -a cmd=("$@")
-    local exec_path
+    local exec_path splash_pid
 
     exec_path="$(command -v "${cmd[0]}")" || return 127
 
     rm -f "${SPLASH_PID_FILE}"
-    start-stop-daemon --start \
-      --background \
-      --make-pidfile \
-      --pidfile "${SPLASH_PID_FILE}" \
-      --stdout /dev/null \
-      --stderr /dev/null \
-      --exec "${exec_path}" -- "${cmd[@]:1}"
+
+    if command -v nohup >/dev/null 2>&1; then
+      nohup "${exec_path}" "${cmd[@]:1}" >/dev/null 2>&1 &
+    else
+      "${exec_path}" "${cmd[@]:1}" >/dev/null 2>&1 &
+    fi
+
+    splash_pid=$!
+    if [[ -n "${splash_pid}" ]] && kill -0 "${splash_pid}" >/dev/null 2>&1; then
+      echo "${splash_pid}" > "${SPLASH_PID_FILE}"
+    fi
   else
     "$@" >/dev/null 2>&1
   fi

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -17,6 +17,53 @@
 ACTION_TYPE="${1}"
 PLATFORM="${2}"
 
+SPLASH_PID_FILE="/tmp/ee_splash_player.pid"
+
+stop_splash_player() {
+  local pid
+
+  [ ! -f "${SPLASH_PID_FILE}" ] && return 0
+
+  while read -r pid; do
+    [[ -z "${pid}" ]] && continue
+    if kill -0 "${pid}" 2>/dev/null; then
+      kill -TERM -"${pid}" 2>/dev/null || kill -TERM "${pid}" 2>/dev/null
+      sleep 0.2
+      if kill -0 "${pid}" 2>/dev/null; then
+        kill -KILL -"${pid}" 2>/dev/null || kill -KILL "${pid}" 2>/dev/null
+      fi
+    fi
+  done < "${SPLASH_PID_FILE}"
+
+  rm -f "${SPLASH_PID_FILE}"
+}
+
+record_splash_pid() {
+  local pid="${1}"
+  echo "${pid}" > "${SPLASH_PID_FILE}"
+}
+
+run_player_command() {
+  local background_mode="${1}"
+  shift
+
+  if [[ "${background_mode}" -eq 1 ]]; then
+    if command -v setsid >/dev/null 2>&1; then
+      setsid "$@" >/dev/null 2>&1 &
+    else
+      "$@" >/dev/null 2>&1 &
+    fi
+    record_splash_pid "$!"
+  else
+    "$@" >/dev/null 2>&1
+  fi
+}
+
+[[ "${ACTION_TYPE}" = "stopplayer" ]] && {
+  stop_splash_player
+  exit 0
+}
+
 GAMELOADINGSPLASH="/storage/.config/splash/loading-game.png"
 BLANKSPLASH="/storage/.config/splash/blank.png"
 DEFAULTSPLASH="/storage/.config/splash/splash-1080.png"
@@ -28,6 +75,8 @@ RANDOMVIDEO="/storage/roms/splash/introvideos"
 PLATFORM=${PLATFORM,,}
 PLAYER_VID="ffplay"
 PLAYER_IMG="mpv"
+
+ASYNC_PLAY=0
 
 have_mpv=0; command -v mpv >/dev/null 2>&1 && have_mpv=1
 
@@ -65,9 +114,11 @@ elif [ "${ACTION_TYPE}" = "blank" ]; then
   SPLASH="${BLANKSPLASH}"
 
 elif [ "${ACTION_TYPE}" = "gameloading" ]; then
+  ASYNC_PLAY=1
+  stop_splash_player
   [[ "${MODE}" == *"x"* ]] && GAMELOADINGSPLASH="/storage/.config/splash/loading-game-std.png"
 
-	EE_SPLASH_LOADING="$(get_ee_setting ee_splashloading)"
+        EE_SPLASH_LOADING="$(get_ee_setting ee_splashloading)"
 	[[ -z "${EE_SPLASH_LOADING}" ]] && EE_SPLASH_LOADING=6
 	
 	CUSTOM_SPLASH_IMAGE="$(get_ee_setting ee_customsplashimage)"
@@ -132,24 +183,31 @@ if [[ -f "/storage/.config/emuelec/configs/novideo" ]] && [[ ${VIDEO} != "1" ]];
 
     if is_image "${SPLASH}"; then
       if [ "${have_mpv}" -eq 1 ]; then
-        ${PLAYER_IMG} --fullscreen --no-keepaspect --vf="${MPV_VF}" --image-display-duration=${DURATION} "${SPLASH}" >/dev/null 2>&1
+        CMD=("${PLAYER_IMG}" --fullscreen --no-keepaspect "--vf=${MPV_VF}")
+        [[ -n "${DURATION}" ]] && CMD+=("--image-display-duration=${DURATION}")
+        CMD+=("${SPLASH}")
+        run_player_command "${ASYNC_PLAY}" "${CMD[@]}"
       else
-        ffplay -fs -autoexit -loglevel error -nostats -vf "${FILTER_FILL}" -t ${DURATION} -loop 1 -framerate 1 -i "${SPLASH}" >/dev/null 2>&1
+        CMD=(ffplay -fs -autoexit -loglevel error -nostats -vf "${FILTER_FILL}")
+        [[ -n "${DURATION}" ]] && CMD+=(-t "${DURATION}")
+        CMD+=(-loop 1 -framerate 1 -i "${SPLASH}")
+        run_player_command "${ASYNC_PLAY}" "${CMD[@]}"
       fi
     elif is_video "${SPLASH}"; then
-      if [ -n "${DURATION}" ] && [ "${DURATION}" -gt 0 ]; then
-        if [ "${PLAYER_VID}" = "ffplay" ]; then
-          ${PLAYER_VID} -fs -autoexit -loglevel error -nostats -vf "${FILTER_FILL}" -t ${DURATION} -i "${SPLASH}" >/dev/null 2>&1
-        else
-          ${PLAYER_VID} --fullscreen --no-keepaspect --vf="${MPV_VF}" --length=${DURATION} "${SPLASH}" >/dev/null 2>&1
+      if [ "${PLAYER_VID}" = "ffplay" ]; then
+        CMD=("${PLAYER_VID}" -fs -autoexit -loglevel error -nostats -vf "${FILTER_FILL}")
+        if [ -n "${DURATION}" ] && [ "${DURATION}" -gt 0 ]; then
+          CMD+=(-t "${DURATION}")
         fi
+        CMD+=(-i "${SPLASH}")
       else
-        if [ "${PLAYER_VID}" = "ffplay" ]; then
-          ${PLAYER_VID} -fs -autoexit -loglevel error -nostats -vf "${FILTER_FILL}" -i "${SPLASH}" >/dev/null 2>&1
-        else
-          ${PLAYER_VID} --fullscreen --no-keepaspect --vf="${MPV_VF}" "${SPLASH}" >/dev/null 2>&1
+        CMD=("${PLAYER_VID}" --fullscreen --no-keepaspect "--vf=${MPV_VF}")
+        if [ -n "${DURATION}" ] && [ "${DURATION}" -gt 0 ]; then
+          CMD+=("--length=${DURATION}")
         fi
+        CMD+=("${SPLASH}")
       fi
+      run_player_command "${ASYNC_PLAY}" "${CMD[@]}"
     fi
   fi
 else
@@ -164,13 +222,20 @@ else
   set_audio alsa
 
   if [ ${SS_DEVICE} -eq 1 ]; then
-    ${PLAYER_VID} --fullscreen --no-keepaspect --vf="${MPV_VF}" "${SPLASH}" >/dev/null 2>&1
+    CMD=("${PLAYER_VID}" --fullscreen --no-keepaspect "--vf=${MPV_VF}")
+    CMD+=("${SPLASH}")
+    run_player_command "${ASYNC_PLAY}" "${CMD[@]}"
   else
-    ${PLAYER_VID} -fs -autoexit -vf "${FILTER_FILL}" -i "${SPLASH}" >/dev/null 2>&1
+    CMD=("${PLAYER_VID}" -fs -autoexit -vf "${FILTER_FILL}" -i "${SPLASH}")
+    run_player_command "${ASYNC_PLAY}" "${CMD[@]}"
   fi
 
   touch "/storage/.config/emuelec/configs/novideo"
 fi
 
-SPLASHTIME="$(get_ee_setting ee_splash.delay)"
-[ -n "${SPLASHTIME}" ] && sleep "${SPLASHTIME}"
+if [[ "${ASYNC_PLAY}" -eq 0 ]]; then
+  SPLASHTIME="$(get_ee_setting ee_splash.delay)"
+  [ -n "${SPLASHTIME}" ] && sleep "${SPLASHTIME}"
+fi
+
+exit 0

--- a/packages/sx05re/emuelec/bin/show_splash.sh
+++ b/packages/sx05re/emuelec/bin/show_splash.sh
@@ -19,63 +19,34 @@ PLATFORM="${2}"
 
 SPLASH_PID_FILE="/tmp/ee_splash_player.pid"
 
-stop_splash_player() {
-  local pid pgid attempt
+reset_video_overlay() {
+  local disable_video osd_clear
 
-  if [[ ! -f "${SPLASH_PID_FILE}" ]]; then
-    if type blank_buffer >/dev/null 2>&1; then
-      blank_buffer >/dev/null 2>&1
-    fi
-    return 0
+  disable_video="/sys/class/video/disable_video"
+  if [[ -w "${disable_video}" ]]; then
+    echo 1 > "${disable_video}" 2>/dev/null
+    echo 0 > "${disable_video}" 2>/dev/null
   fi
 
-  while read -r pid; do
-    [[ -z "${pid}" ]] && continue
-    if ! kill -0 "${pid}" 2>/dev/null; then
-      continue
-    fi
+  osd_clear="/sys/class/graphics/fb0/osd_clear"
+  if [[ -w "${osd_clear}" ]]; then
+    echo 1 > "${osd_clear}" 2>/dev/null
+  fi
+}
 
-    pgid="$(ps -o pgid= -p "${pid}" 2>/dev/null | tr -d ' ')"
+stop_splash_player() {
+  if [[ -f "${SPLASH_PID_FILE}" ]]; then
+    start-stop-daemon --stop \
+      --pidfile "${SPLASH_PID_FILE}" \
+      --retry TERM/5/KILL/5 >/dev/null 2>&1
+    rm -f "${SPLASH_PID_FILE}"
+  fi
 
-    if [[ -n "${pgid}" ]] && [[ "${pgid}" =~ ^[0-9]+$ ]]; then
-      kill -TERM -"${pgid}" 2>/dev/null
-    fi
-    kill -TERM "${pid}" 2>/dev/null
-
-    attempt=0
-    while kill -0 "${pid}" 2>/dev/null && (( attempt < 20 )); do
-      sleep 0.05
-      attempt=$((attempt + 1))
-    done
-
-    if kill -0 "${pid}" 2>/dev/null; then
-      if [[ -n "${pgid}" ]] && [[ "${pgid}" =~ ^[0-9]+$ ]]; then
-        kill -KILL -"${pgid}" 2>/dev/null
-      fi
-      kill -KILL "${pid}" 2>/dev/null
-    fi
-
-    attempt=0
-    while kill -0 "${pid}" 2>/dev/null && (( attempt < 40 )); do
-      sleep 0.05
-      attempt=$((attempt + 1))
-    done
-
-    if ! kill -0 "${pid}" 2>/dev/null; then
-      wait "${pid}" 2>/dev/null
-    fi
-  done < "${SPLASH_PID_FILE}"
-
-  rm -f "${SPLASH_PID_FILE}"
+  reset_video_overlay
 
   if type blank_buffer >/dev/null 2>&1; then
     blank_buffer >/dev/null 2>&1
   fi
-}
-
-record_splash_pid() {
-  local pid="${1}"
-  echo "${pid}" > "${SPLASH_PID_FILE}"
 }
 
 run_player_command() {
@@ -83,8 +54,19 @@ run_player_command() {
   shift
 
   if [[ "${background_mode}" -eq 1 ]]; then
-    nohup "$@" >/dev/null 2>&1 &
-    record_splash_pid "$!"
+    local -a cmd=("$@")
+    local exec_path
+
+    exec_path="$(command -v "${cmd[0]}")" || return 127
+
+    rm -f "${SPLASH_PID_FILE}"
+    start-stop-daemon --start \
+      --background \
+      --make-pidfile \
+      --pidfile "${SPLASH_PID_FILE}" \
+      --stdout /dev/null \
+      --stderr /dev/null \
+      --exec "${exec_path}" -- "${cmd[@]:1}"
   else
     "$@" >/dev/null 2>&1
   fi


### PR DESCRIPTION
## Summary
- add a managed background player for game loading splashes so the process can be stopped on demand
- ensure the emulator launcher starts emulators asynchronously and stops the splash player as soon as the process begins

## Testing
- bash -n packages/sx05re/emuelec/bin/show_splash.sh
- bash -n packages/sx05re/emuelec/bin/emuelecRunEmu.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2a8d3cf108320bcde1779b85ef6db