### PR TITLE
Avoid blanking framebuffer during core start

### DIFF
--- a/packages/sx05re/emuelec/bin/emuelec-utils
+++ b/packages/sx05re/emuelec/bin/emuelec-utils
@@ -470,7 +470,7 @@ function init_app_video() {
 	[ "${SPL}" -eq "1" ] && ${TBASH} show_splash.sh gameloading "${PLATFORM}" "${ROMNAME}"
 
 	# Set the display video to that of the emulator setting.
-	[ ! -z "${VIDEO_EMU}" ] && ${TBASH} setres.sh "${VIDEO_EMU}" "${PLATFORM}" "${BASEROMNAME}" # set display
+        [ ! -z "${VIDEO_EMU}" ] && EE_SKIP_FB_CLEAR=1 ${TBASH} setres.sh "${VIDEO_EMU}" "${PLATFORM}" "${BASEROMNAME}"
 }
 
 function end_app_video() {

--- a/packages/sx05re/emuelec/bin/setres.sh
+++ b/packages/sx05re/emuelec/bin/setres.sh
@@ -17,6 +17,12 @@
 
 FILE_MODE="/sys/class/display/mode"
 PLATFORM=""
+SKIP_FB_CLEAR="${EE_SKIP_FB_CLEAR:-0}"
+
+blank_if_allowed() {
+  [[ "${SKIP_FB_CLEAR}" == "1" ]] && return
+  blank_buffer "$@"
+}
 
 #here we look for the best framebuffer; the default is fb0, but on some devices it is fb1. Here we choose the best available,
 #thus achieving the best video performance. 
@@ -44,7 +50,7 @@ switch_resolution()
 
   # Here we first clear the primary display buffer of leftover artifacts then set
   # the secondary small buffers flag to stop copying across.
-  blank_buffer >> /dev/null
+  blank_if_allowed >> /dev/null
 
   case ${MODE} in
     480cvbs|576cvbs|480p*|480i*|576p*|720p*|1080p*|1440p*|2160p*|576i*|720i*|1080i*|1440i*|2160i*|*x*)
@@ -161,7 +167,7 @@ FBH=0
 
 # Here we first clear the primary display buffer of leftover artifacts then set
 # the secondary small buffers flag to stop copying across.
-blank_buffer >> /dev/null
+blank_if_allowed >> /dev/null
 
 # The current display mode before it may get changed below.
 OLD_MODE=$( cat ${FILE_MODE} )
@@ -227,7 +233,7 @@ CURRENT_MODE=$( cat ${FILE_MODE} )
 if [[ "${CURRENT_MODE}" == "${MODE}" ]]; then
   echo "SET MAIN FRAME BUFFER"
   set_main_framebuffer ${FBW} ${FBH} 
-  blank_buffer
+  blank_if_allowed
 fi
 
 # Now that the primary buffer has been acquired we blank it again because the new


### PR DESCRIPTION
## Summary
- gate framebuffer clearing in setres.sh behind an opt-out flag
- skip framebuffer blanking during resolution switches triggered while launching a core

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7d7831b1883209cfee0db4c5aabdb