### PR TITLE
Fix mali-fbdev SDL driver multi-window handling

### DIFF
--- a/docs/amiberry-gui-regression.md
+++ b/docs/amiberry-gui-regression.md
@@ -1,0 +1,22 @@
+# Amiberry GUI crash on EmuELEC when using the hotkey
+
+## Summary
+
+Starting with the EmuELEC package update to Amiberry commit `ecef2fd19f61e9360869eb9d5ebe1ad4c5019c14` (tagged upstream as v7.7), pressing the Amiberry hotkey to open the GUI on Amlogic devices aborts with the log message:
+
+```
+INFO: Creating Amiberry GUI window...
+Unable to create window: mali-fbdev: Can't create EGL window surface
+```
+
+The failure is reproducible on platforms that rely on the `mali-fbdev` SDL2 video backend (used on EmuELEC's Amlogic builds). In Amiberry v5.5 the same workflow completed successfully.
+
+## Root cause
+
+The SDL2 backend that EmuELEC ships for `mali-fbdev` supports only a single EGL window surface. When a second SDL window is requested, `SDL_EGL_CreateSurface` fails and SDL returns the error "Can't create EGL window surface". The backend explicitly sets the `SDL_WINDOW_OPENGL` flag on every new window and aborts when the surface allocation fails, which matches the crash observed when Amiberry 7.7 tries to spawn a dedicated GUI window.
+
+The package bump introduced in EmuELEC commit `e9b20dbc70dd94addd5c7e6eb7b48cc7c1628bbc` updated Amiberry from the previously working commit `fc0645c51ce095f3f46c4faa70f9afab71d49526` (v5.5) to `ecef2fd19f61e9360869eb9d5ebe1ad4c5019c14`. Upstream Amiberry started creating an additional GUI window in that range, triggering the `mali-fbdev` limitation and leading to the regression.
+
+## Recommendation
+
+Reverting to the last known good upstream commit (`fc0645c51ce095f3f46c4faa70f9afab71d49526`) or patching Amiberry so that the GUI reuses the existing window on `mali-fbdev` devices avoids the crash until the SDL driver gains multi-window support. Alternatively, Amiberry could guard the new GUI path behind a runtime check that falls back to the legacy behaviour when `SDL_VIDEODRIVER` is `mali-fbdev`.

--- a/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
+++ b/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
@@ -531,7 +531,7 @@ index 000000000..557c13f67
 +    /* Windows have one size for now */
 +    window->w = displaydata->width;
 +    window->h = displaydata->height;
-
++
 +    windowdata->native_window.width = window->w;
 +    windowdata->native_window.height = window->h;
 +

--- a/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
+++ b/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
@@ -438,11 +438,13 @@ index 000000000..557c13f67
 +
 +    fd = open("/dev/fb0", O_RDWR, 0);
 +    if (fd < 0) {
++        SDL_free(data);
 +        return SDL_SetError("mali-fbdev: Could not open framebuffer device");
 +    }
 +
 +    if (ioctl(fd, FBIOGET_VSCREENINFO, &vinfo) < 0) {
-+        MALI_VideoQuit(_this);
++        close(fd);
++        SDL_free(data);
 +        return SDL_SetError("mali-fbdev: Could not get framebuffer information");
 +    }
 +    /* Enable triple buffering */
@@ -519,8 +521,13 @@ index 000000000..557c13f67
 +{
 +    SDL_WindowData *windowdata;
 +    SDL_DisplayData *displaydata;
++    SDL_VideoDisplay *display;
 +
-+    displaydata = SDL_GetDisplayDriverData(0);
++    display = SDL_GetDisplayForWindow(window);
++    displaydata = (display != NULL) ? (SDL_DisplayData *) display->driverdata : NULL;
++    if (displaydata == NULL) {
++        return SDL_SetError("mali-fbdev: Missing display configuration");
++    }
 +
 +    /* Allocate window internal data */
 +    windowdata = (SDL_WindowData *) SDL_calloc(1, sizeof(SDL_WindowData));
@@ -540,13 +547,14 @@ index 000000000..557c13f67
 +
 +    if (!_this->egl_data) {
 +        if (SDL_GL_LoadLibrary(NULL) < 0) {
++            SDL_free(windowdata);
 +            return -1;
 +        }
 +    }
 +    windowdata->egl_surface = SDL_EGL_CreateSurface(_this, (NativeWindowType) &windowdata->native_window);
 +
 +    if (windowdata->egl_surface == EGL_NO_SURFACE) {
-+        MALI_VideoQuit(_this);
++        SDL_free(windowdata);
 +        return SDL_SetError("mali-fbdev: Can't create EGL window surface");
 +    }
 +
@@ -637,8 +645,7 @@ index 000000000..65c81d9a4
 --- /dev/null
 +++ b/src/video/mali-fbdev/SDL_malivideo.h
 @@ -0,0 +1,54 @@
-+#ifndef _SDL_malivideo_h
-+#define _SDL_malivideo_h
++#pragma once
 +
 +#include "../../SDL_internal.h"
 +#include "../SDL_sysvideo.h"
@@ -646,6 +653,7 @@ index 000000000..65c81d9a4
 +#include "SDL_egl.h"
 +
 +#include <EGL/egl.h>
++#include <EGL/fbdev_window.h>
 +#include <linux/vt.h>
 +#include <linux/fb.h>
 +#include <sys/types.h>
@@ -690,8 +698,6 @@ index 000000000..65c81d9a4
 +
 +/* Event functions */
 +void MALI_PumpEvents(_THIS);
-+
-+#endif /* _SDL_malivideo_h */
 +
 -- 
 2.37.1

--- a/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
+++ b/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
@@ -455,8 +455,8 @@ index 000000000..557c13f67
 +    close(fd);
 +    system("setterm -cursor off");
 +
-+    data->native_display.width = vinfo.xres;
-+    data->native_display.height = vinfo.yres;
++    data->width = vinfo.xres;
++    data->height = vinfo.yres;
 +
 +    SDL_zero(current_mode);
 +    current_mode.w = vinfo.xres;
@@ -529,8 +529,11 @@ index 000000000..557c13f67
 +    }
 +
 +    /* Windows have one size for now */
-+    window->w = displaydata->native_display.width;
-+    window->h = displaydata->native_display.height;
++    window->w = displaydata->width;
++    window->h = displaydata->height;
+
++    windowdata->native_window.width = window->w;
++    windowdata->native_window.height = window->h;
 +
 +    /* OpenGL ES is the law here */
 +    window->flags |= SDL_WINDOW_OPENGL;
@@ -540,7 +543,7 @@ index 000000000..557c13f67
 +            return -1;
 +        }
 +    }
-+    windowdata->egl_surface = SDL_EGL_CreateSurface(_this, (NativeWindowType) &displaydata->native_display);
++    windowdata->egl_surface = SDL_EGL_CreateSurface(_this, (NativeWindowType) &windowdata->native_window);
 +
 +    if (windowdata->egl_surface == EGL_NO_SURFACE) {
 +        MALI_VideoQuit(_this);
@@ -654,11 +657,13 @@ index 000000000..65c81d9a4
 +
 +typedef struct SDL_DisplayData
 +{
-+    struct fbdev_window native_display;
++    int width;
++    int height;
 +} SDL_DisplayData;
 +
 +typedef struct SDL_WindowData
 +{
++    struct fbdev_window native_window;
 +    EGLSurface egl_surface;
 +} SDL_WindowData;
 +

--- a/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
+++ b/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
@@ -647,7 +647,8 @@ index 000000000..65c81d9a4
 @@ -0,0 +1,54 @@
 +#include "../../SDL_internal.h"
 +
-+#pragma once
++#ifndef _SDL_malivideo_h
++#define _SDL_malivideo_h
 +
 +#include "../SDL_sysvideo.h"
 +
@@ -699,6 +700,8 @@ index 000000000..65c81d9a4
 +
 +/* Event functions */
 +void MALI_PumpEvents(_THIS);
++
++#endif /* _SDL_malivideo_h */
 
 -- 
 2.37.1

--- a/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
+++ b/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
@@ -645,7 +645,8 @@ index 000000000..65c81d9a4
 --- /dev/null
 +++ b/src/video/mali-fbdev/SDL_malivideo.h
 @@ -0,0 +1,54 @@
-+#pragma once
++#ifndef _SDL_malivideo_h
++#define _SDL_malivideo_h
 +
 +#include "../../SDL_internal.h"
 +#include "../SDL_sysvideo.h"
@@ -698,6 +699,8 @@ index 000000000..65c81d9a4
 +
 +/* Event functions */
 +void MALI_PumpEvents(_THIS);
+
++#endif /* _SDL_malivideo_h */
 +
 -- 
 2.37.1

--- a/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
+++ b/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
@@ -645,10 +645,10 @@ index 000000000..65c81d9a4
 --- /dev/null
 +++ b/src/video/mali-fbdev/SDL_malivideo.h
 @@ -0,0 +1,54 @@
-+#include "../../SDL_internal.h"
-+
 +#ifndef _SDL_malivideo_h
 +#define _SDL_malivideo_h
++
++#include "../../SDL_internal.h"
 +
 +#include "../SDL_sysvideo.h"
 +

--- a/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
+++ b/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
@@ -645,7 +645,8 @@ index 000000000..65c81d9a4
 --- /dev/null
 +++ b/src/video/mali-fbdev/SDL_malivideo.h
 @@ -0,0 +1,54 @@
-+#pragma once
++#ifndef _SDL_malivideo_h
++#define _SDL_malivideo_h
 +
 +#include "../../SDL_internal.h"
 +#include "../SDL_sysvideo.h"
@@ -699,6 +700,8 @@ index 000000000..65c81d9a4
 +/* Event functions */
 +void MALI_PumpEvents(_THIS);
 +
++#endif /* _SDL_malivideo_h */
+
 -- 
 2.37.1
 

--- a/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
+++ b/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
@@ -645,8 +645,7 @@ index 000000000..65c81d9a4
 --- /dev/null
 +++ b/src/video/mali-fbdev/SDL_malivideo.h
 @@ -0,0 +1,54 @@
-+#ifndef _SDL_malivideo_h
-+#define _SDL_malivideo_h
++#pragma once
 +
 +#include "../../SDL_internal.h"
 +#include "../SDL_sysvideo.h"
@@ -699,8 +698,6 @@ index 000000000..65c81d9a4
 +
 +/* Event functions */
 +void MALI_PumpEvents(_THIS);
-
-+#endif /* _SDL_malivideo_h */
 +
 -- 
 2.37.1

--- a/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
+++ b/packages/multimedia/SDL2/patches/Amlogic/0001-mali-fbdev-add-driver.patch
@@ -645,10 +645,10 @@ index 000000000..65c81d9a4
 --- /dev/null
 +++ b/src/video/mali-fbdev/SDL_malivideo.h
 @@ -0,0 +1,54 @@
-+#ifndef _SDL_malivideo_h
-+#define _SDL_malivideo_h
-+
 +#include "../../SDL_internal.h"
++
++#pragma once
++
 +#include "../SDL_sysvideo.h"
 +
 +#include "SDL_egl.h"
@@ -699,8 +699,6 @@ index 000000000..65c81d9a4
 +
 +/* Event functions */
 +void MALI_PumpEvents(_THIS);
-+
-+#endif /* _SDL_malivideo_h */
 
 -- 
 2.37.1


### PR DESCRIPTION
## Summary
- update the mali-fbdev SDL driver patch to track display dimensions instead of a shared fbdev_window
- create a dedicated fbdev_window structure for each SDL window so additional EGL surfaces can be created without failing

## Testing
- not run (platform-specific)


------
https://chatgpt.com/codex/tasks/task_e_68ea2cd7f010832081c8102c6547e284