### PR TITLE
Add multi-macro support for controller automation

### DIFF
--- a/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
@@ -4,14 +4,46 @@ import os
 import json
 import time
 import builtins
-from functools import partial
 from evdev import InputDevice, list_devices, ecodes as e
 from evdev import UInput
 
 CONFIG_FILE = "/storage/.config/emuelec/scripts/macro_config.json"
 
-# Ensure console output shows immediately on screen.
-print = partial(builtins.print, flush=True)
+# Ensure console output shows immediately on screen. When called from the
+# EmulationStation menu the script runs through a tee pipeline, so we mirror all
+# stdout messages to the active framebuffer console to keep them visible on the
+# TV while preserving the log.
+
+
+def setup_console_print():
+    original_print = builtins.print
+    tty_handle = None
+
+    for path in ("/dev/tty0", "/dev/console"):
+        try:
+            tty_handle = open(path, "w", buffering=1)
+            break
+        except OSError:
+            continue
+
+    def console_print(*args, **kwargs):
+        target = kwargs.get("file", sys.stdout)
+        kwargs.pop("flush", None)
+        original_print(*args, **kwargs, flush=True)
+
+        if tty_handle and target in (None, sys.stdout):
+            mirror_kwargs = dict(kwargs)
+            mirror_kwargs["file"] = tty_handle
+            try:
+                original_print(*args, **mirror_kwargs, flush=True)
+            except OSError:
+                tty_handle.close()
+                tty_handle = None
+
+    return console_print
+
+
+print = setup_console_print()
 
 
 def load_config():

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
+import atexit
 import sys
 import os
 import json
 import time
 import builtins
-import functools
 from evdev import InputDevice, list_devices, ecodes as e
 from evdev import UInput
 
@@ -17,9 +17,93 @@ if hasattr(sys.stdout, "reconfigure"):
         pass
 
 
-# Every print call should flush immediately so prompts appear on the EmuELEC
-# console even when the script runs through a tee pipeline.
-print = functools.partial(builtins.print, flush=True)
+class ConsoleMirror:
+    """Mirror stdout to the active EmuELEC console if available."""
+
+    def __init__(self):
+        self._fd = None
+        self._candidates = [
+            "/tmp/display",
+            "/dev/tty0",
+            "/dev/tty1",
+            "/dev/console",
+        ]
+
+    def _open_target(self):
+        if self._fd is not None:
+            return True
+
+        for path in self._candidates:
+            try:
+                fd = os.open(path, os.O_WRONLY | os.O_NONBLOCK)
+            except OSError:
+                continue
+
+            self._fd = fd
+            return True
+
+        return False
+
+    def write(self, text):
+        if not text:
+            return
+
+        data = text.encode("utf-8", "replace")
+
+        if self._fd is None and not self._open_target():
+            return
+
+        try:
+            os.write(self._fd, data)
+        except OSError:
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+            finally:
+                self._fd = None
+
+            if self._open_target():
+                try:
+                    os.write(self._fd, data)
+                except OSError:
+                    pass
+
+    def close(self):
+        if self._fd is not None:
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+            finally:
+                self._fd = None
+
+
+_builtin_print = builtins.print
+_console_mirror = ConsoleMirror()
+atexit.register(_console_mirror.close)
+
+
+def console_print(*args, **kwargs):
+    file = kwargs.get("file", sys.stdout)
+    sep = kwargs.get("sep", " ")
+    end = kwargs.get("end", "\n")
+
+    if file is sys.stdout or file is None:
+        if not args:
+            mirrored = end
+        else:
+            mirrored = sep.join(str(arg) for arg in args) + end
+
+        _console_mirror.write(mirrored)
+
+        kwargs = dict(kwargs)
+        kwargs["flush"] = True
+
+    _builtin_print(*args, **kwargs)
+
+
+print = console_print
 
 
 def load_config():

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
@@ -1,17 +1,55 @@
 #!/usr/bin/env python3
 import sys
 import os
-sys.path.insert(0, '/storage/.config/emuelec/scripts/')
-from evdev import InputDevice, list_devices, ecodes as e
-from evdev import UInput
 import json
 import time
-import os
+from evdev import InputDevice, list_devices, ecodes as e
+from evdev import UInput
 
 CONFIG_FILE = "/storage/.config/emuelec/scripts/macro_config.json"
 
-def wait_for_controller():
+
+def load_config():
+    if not os.path.exists(CONFIG_FILE):
+        print("❌ No saved configuration found. Please run Setup first!")
+        sys.exit(1)
+
+    with open(CONFIG_FILE, "r") as f:
+        data = json.load(f)
+
+    if "macros" not in data:
+        # migrate legacy single-macro format on the fly
+        data = {
+            "device_path": data.get("device_path"),
+            "macros": [
+                {
+                    "name": "DEFAULT MACRO",
+                    "trigger_code": data.get("trigger_code"),
+                    "macro_keys": data.get("macro_keys", []),
+                }
+            ],
+        }
+
+    macros = [m for m in data.get("macros", []) if m.get("macro_keys")]
+    if not macros:
+        print("❌ No macros stored in configuration. Please create one with Setup!")
+        sys.exit(1)
+
+    data["macros"] = macros
+    return data
+
+
+def wait_for_controller(preferred_path=None):
     print("\n🔌 Waiting for controller...")
+
+    if preferred_path:
+        try:
+            dev = InputDevice(preferred_path)
+            print(f"🎮 Controller found: {dev.name} ({dev.path})")
+            return dev
+        except OSError:
+            pass
+
     while True:
         devices = [InputDevice(path) for path in list_devices()]
         for dev in devices:
@@ -22,14 +60,46 @@ def wait_for_controller():
                     return dev
         time.sleep(1)
 
-def load_config():
-    if not os.path.exists(CONFIG_FILE):
-        print("❌ No saved configuration found. Please run Setup first!")
-        exit(1)
-    with open(CONFIG_FILE, "r") as f:
-        return json.load(f)
 
-def run_macro_mode(dev, trigger_code, macro_keys):
+def clear_console():
+    print("\033c", end="")
+
+
+def controller_menu(dev, title, options):
+    index = 0
+
+    while True:
+        clear_console()
+        print(title)
+        print("\nUse D-Pad to choose a macro and press (A) to confirm.")
+        print("Press (B) to cancel and exit.")
+        print()
+
+        for i, option in enumerate(options):
+            prefix = "👉" if i == index else "  "
+            print(f"{prefix} {option}")
+
+        for event in dev.read_loop():
+            if event.type != e.EV_KEY or event.value != 1:
+                continue
+
+            if event.code == e.BTN_DPAD_DOWN:
+                index = (index + 1) % len(options)
+                break
+            if event.code == e.BTN_DPAD_UP:
+                index = (index - 1) % len(options)
+                break
+            if event.code == e.BTN_SOUTH:
+                return index
+            if event.code == e.BTN_EAST:
+                print("\n❌ Macro activation cancelled.")
+                sys.exit(0)
+
+
+def run_macro_mode(dev, macro):
+    trigger_code = macro["trigger_code"]
+    macro_keys = macro["macro_keys"]
+
     ui = UInput({e.EV_KEY: list(set(macro_keys))}, name="Virtual-Macro", bustype=e.BUS_USB)
     trigger_pressed = False
     macro_executed = False
@@ -70,10 +140,19 @@ def run_macro_mode(dev, trigger_code, macro_keys):
                 ui.write(e.EV_KEY, key, 0)
                 ui.syn()
 
+
 def main():
     config = load_config()
-    dev = wait_for_controller()
-    run_macro_mode(dev, config["trigger_code"], config["macro_keys"])
+    macros = config["macros"]
+
+    dev = wait_for_controller(config.get("device_path"))
+
+    option_labels = [f"{macro['name']} (Trigger {macro['trigger_code']})" for macro in macros]
+    selection = controller_menu(dev, "🎛  Select macro to activate", option_labels)
+    chosen_macro = macros[selection]
+
+    run_macro_mode(dev, chosen_macro)
+
 
 if __name__ == "__main__":
     main()

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
@@ -5,6 +5,7 @@ import json
 import time
 import stat
 import builtins
+from typing import Optional
 from evdev import InputDevice, list_devices, ecodes as e
 from evdev import UInput
 
@@ -17,19 +18,25 @@ CONFIG_FILE = "/storage/.config/emuelec/scripts/macro_config.json"
 
 
 class ConsoleMirror:
-    def __init__(self, original_print):
-        self._print = original_print
-        self._handle = None
-        self._path = None
-        self._candidates = ("/tmp/display", "/dev/tty0", "/dev/console")
+    """Mirror stdout to the device's active console."""
 
-    def _open_candidate(self, path):
+    def __init__(self):
+        self._fd: Optional[int] = None
+        self._path: Optional[str] = None
+        self._candidates = (
+            "/tmp/display",
+            "/dev/tty1",
+            "/dev/tty0",
+            "/dev/console",
+        )
+
+    def _open_candidate(self, path: str) -> Optional[int]:
         try:
             mode = os.stat(path).st_mode
         except OSError:
             return None
 
-        flags = os.O_WRONLY
+        flags = os.O_WRONLY | os.O_CLOEXEC
         if stat.S_ISFIFO(mode):
             flags |= os.O_NONBLOCK
 
@@ -38,62 +45,65 @@ class ConsoleMirror:
         except OSError:
             return None
 
-        try:
-            handle = os.fdopen(fd, "w", buffering=1, encoding="utf-8", errors="replace")
-        except OSError:
-            os.close(fd)
-            return None
+        return fd
 
-        return handle
-
-    def _ensure_handle(self):
-        if self._handle:
+    def _ensure_fd(self) -> bool:
+        if self._fd is not None:
             return True
 
         for path in self._candidates:
-            handle = self._open_candidate(path)
-            if handle:
-                self._handle = handle
+            fd = self._open_candidate(path)
+            if fd is not None:
+                self._fd = fd
                 self._path = path
                 return True
         return False
 
-    def _close_handle(self):
-        if not self._handle:
+    def _close_fd(self) -> None:
+        if self._fd is None:
             return
+
         try:
-            self._handle.close()
+            os.close(self._fd)
         except OSError:
             pass
-        self._handle = None
+        self._fd = None
         self._path = None
 
-    def print(self, *args, **kwargs):
-        target = kwargs.get("file", sys.stdout)
-        kwargs.pop("flush", None)
-        self._print(*args, **kwargs, flush=True)
-
-        if target not in (None, sys.stdout):
+    def write(self, text: str) -> None:
+        if not text:
             return
 
-        if not self._ensure_handle():
+        if not self._ensure_fd():
             return
 
-        mirror_kwargs = dict(kwargs)
-        mirror_kwargs["file"] = self._handle
+        data = text.encode("utf-8", "replace")
         try:
-            self._print(*args, **mirror_kwargs, flush=True)
+            os.write(self._fd, data)
         except OSError:
-            self._close_handle()
+            self._close_fd()
+
+
+class PrintWrapper:
+    def __init__(self, original_print):
+        self._print = original_print
+        self._mirror = ConsoleMirror()
+
+    def __call__(self, *args, **kwargs):
+        target = kwargs.get("file", sys.stdout)
+        sep = kwargs.get("sep", " ")
+        end = kwargs.get("end", "\n")
+
+        text = sep.join(str(arg) for arg in args) + end
+        kwargs["flush"] = True
+        self._print(*args, **kwargs)
+
+        if target in (None, sys.stdout):
+            self._mirror.write(text)
 
 
 def setup_console_print():
-    mirror = ConsoleMirror(builtins.print)
-
-    def console_print(*args, **kwargs):
-        mirror.print(*args, **kwargs)
-
-    return console_print
+    return PrintWrapper(builtins.print)
 
 
 if hasattr(sys.stdout, "reconfigure"):

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
@@ -27,6 +27,7 @@ def setup_console_print():
             continue
 
     def console_print(*args, **kwargs):
+        nonlocal tty_handle
         target = kwargs.get("file", sys.stdout)
         kwargs.pop("flush", None)
         original_print(*args, **kwargs, flush=True)

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
@@ -3,108 +3,12 @@ import sys
 import os
 import json
 import time
-import stat
 import builtins
-from typing import Optional
+import functools
 from evdev import InputDevice, list_devices, ecodes as e
 from evdev import UInput
 
 CONFIG_FILE = "/storage/.config/emuelec/scripts/macro_config.json"
-
-# Ensure console output shows immediately on screen. When called from the
-# EmulationStation menu the script runs through a tee pipeline, so we mirror all
-# stdout messages to the active console device (/tmp/display preferred) while
-# preserving logging via stdout.
-
-
-class ConsoleMirror:
-    """Mirror stdout to the device's active console."""
-
-    def __init__(self):
-        self._fd: Optional[int] = None
-        self._path: Optional[str] = None
-        self._candidates = (
-            "/tmp/display",
-            "/dev/tty1",
-            "/dev/tty0",
-            "/dev/console",
-        )
-
-    def _open_candidate(self, path: str) -> Optional[int]:
-        try:
-            mode = os.stat(path).st_mode
-        except OSError:
-            return None
-
-        flags = os.O_WRONLY | os.O_CLOEXEC
-        if stat.S_ISFIFO(mode):
-            flags |= os.O_NONBLOCK
-
-        try:
-            fd = os.open(path, flags)
-        except OSError:
-            return None
-
-        return fd
-
-    def _ensure_fd(self) -> bool:
-        if self._fd is not None:
-            return True
-
-        for path in self._candidates:
-            fd = self._open_candidate(path)
-            if fd is not None:
-                self._fd = fd
-                self._path = path
-                return True
-        return False
-
-    def _close_fd(self) -> None:
-        if self._fd is None:
-            return
-
-        try:
-            os.close(self._fd)
-        except OSError:
-            pass
-        self._fd = None
-        self._path = None
-
-    def write(self, text: str) -> None:
-        if not text:
-            return
-
-        if not self._ensure_fd():
-            return
-
-        data = text.encode("utf-8", "replace")
-        try:
-            os.write(self._fd, data)
-        except OSError:
-            self._close_fd()
-
-
-class PrintWrapper:
-    def __init__(self, original_print):
-        self._print = original_print
-        self._mirror = ConsoleMirror()
-
-    def __call__(self, *args, **kwargs):
-        target = kwargs.get("file", sys.stdout)
-        sep = kwargs.get("sep", " ")
-        end = kwargs.get("end", "\n")
-
-        text = sep.join(str(arg) for arg in args) + end
-        kwargs["flush"] = True
-        self._print(*args, **kwargs)
-
-        if target in (None, sys.stdout):
-            self._mirror.write(text)
-
-
-def setup_console_print():
-    return PrintWrapper(builtins.print)
-
 
 if hasattr(sys.stdout, "reconfigure"):
     try:
@@ -113,7 +17,9 @@ if hasattr(sys.stdout, "reconfigure"):
         pass
 
 
-print = setup_console_print()
+# Every print call should flush immediately so prompts appear on the EmuELEC
+# console even when the script runs through a tee pipeline.
+print = functools.partial(builtins.print, flush=True)
 
 
 def load_config():

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
@@ -3,6 +3,7 @@ import sys
 import os
 import json
 import time
+import stat
 import builtins
 from evdev import InputDevice, list_devices, ecodes as e
 from evdev import UInput
@@ -11,37 +12,95 @@ CONFIG_FILE = "/storage/.config/emuelec/scripts/macro_config.json"
 
 # Ensure console output shows immediately on screen. When called from the
 # EmulationStation menu the script runs through a tee pipeline, so we mirror all
-# stdout messages to the active framebuffer console to keep them visible on the
-# TV while preserving the log.
+# stdout messages to the active console device (/tmp/display preferred) while
+# preserving logging via stdout.
+
+
+class ConsoleMirror:
+    def __init__(self, original_print):
+        self._print = original_print
+        self._handle = None
+        self._path = None
+        self._candidates = ("/tmp/display", "/dev/tty0", "/dev/console")
+
+    def _open_candidate(self, path):
+        try:
+            mode = os.stat(path).st_mode
+        except OSError:
+            return None
+
+        flags = os.O_WRONLY
+        if stat.S_ISFIFO(mode):
+            flags |= os.O_NONBLOCK
+
+        try:
+            fd = os.open(path, flags)
+        except OSError:
+            return None
+
+        try:
+            handle = os.fdopen(fd, "w", buffering=1, encoding="utf-8", errors="replace")
+        except OSError:
+            os.close(fd)
+            return None
+
+        return handle
+
+    def _ensure_handle(self):
+        if self._handle:
+            return True
+
+        for path in self._candidates:
+            handle = self._open_candidate(path)
+            if handle:
+                self._handle = handle
+                self._path = path
+                return True
+        return False
+
+    def _close_handle(self):
+        if not self._handle:
+            return
+        try:
+            self._handle.close()
+        except OSError:
+            pass
+        self._handle = None
+        self._path = None
+
+    def print(self, *args, **kwargs):
+        target = kwargs.get("file", sys.stdout)
+        kwargs.pop("flush", None)
+        self._print(*args, **kwargs, flush=True)
+
+        if target not in (None, sys.stdout):
+            return
+
+        if not self._ensure_handle():
+            return
+
+        mirror_kwargs = dict(kwargs)
+        mirror_kwargs["file"] = self._handle
+        try:
+            self._print(*args, **mirror_kwargs, flush=True)
+        except OSError:
+            self._close_handle()
 
 
 def setup_console_print():
-    original_print = builtins.print
-    tty_handle = None
-
-    for path in ("/dev/tty0", "/dev/console"):
-        try:
-            tty_handle = open(path, "w", buffering=1)
-            break
-        except OSError:
-            continue
+    mirror = ConsoleMirror(builtins.print)
 
     def console_print(*args, **kwargs):
-        nonlocal tty_handle
-        target = kwargs.get("file", sys.stdout)
-        kwargs.pop("flush", None)
-        original_print(*args, **kwargs, flush=True)
-
-        if tty_handle and target in (None, sys.stdout):
-            mirror_kwargs = dict(kwargs)
-            mirror_kwargs["file"] = tty_handle
-            try:
-                original_print(*args, **mirror_kwargs, flush=True)
-            except OSError:
-                tty_handle.close()
-                tty_handle = None
+        mirror.print(*args, **kwargs)
 
     return console_print
+
+
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(line_buffering=True, write_through=True)
+    except (ValueError, OSError):
+        pass
 
 
 print = setup_console_print()

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrorun.py
@@ -3,10 +3,15 @@ import sys
 import os
 import json
 import time
+import builtins
+from functools import partial
 from evdev import InputDevice, list_devices, ecodes as e
 from evdev import UInput
 
 CONFIG_FILE = "/storage/.config/emuelec/scripts/macro_config.json"
+
+# Ensure console output shows immediately on screen.
+print = partial(builtins.print, flush=True)
 
 
 def load_config():
@@ -62,7 +67,7 @@ def wait_for_controller(preferred_path=None):
 
 
 def clear_console():
-    print("\033c", end="")
+    print("\033[2J\033[H", end="")
 
 
 def controller_menu(dev, title, options):

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
@@ -4,15 +4,49 @@ import json
 import os
 import time
 import builtins
-from functools import partial
+import sys
 
 CONFIG_FILE = "/storage/.config/emuelec/scripts/macro_config.json"
 MAX_NAME_LEN = 16
 NAME_ALPHABET = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_")
 
 # Ensure everything printed by the script is flushed immediately so it appears
-# on the on-device console.
-print = partial(builtins.print, flush=True)
+# on the on-device console. When executed from the EmulationStation UI the
+# script's stdout is piped through tee, which prevents text from reaching the
+# TV unless we also write directly to the active framebuffer console.  We keep
+# logging through stdout (for /tmp/macrosetup.log) while mirroring all messages
+# to /dev/tty0 (or /dev/console as a fallback).
+
+
+def setup_console_print():
+    original_print = builtins.print
+    tty_handle = None
+
+    for path in ("/dev/tty0", "/dev/console"):
+        try:
+            tty_handle = open(path, "w", buffering=1)
+            break
+        except OSError:
+            continue
+
+    def console_print(*args, **kwargs):
+        target = kwargs.get("file", sys.stdout)
+        kwargs.pop("flush", None)
+        original_print(*args, **kwargs, flush=True)
+
+        if tty_handle and target in (None, sys.stdout):
+            mirror_kwargs = dict(kwargs)
+            mirror_kwargs["file"] = tty_handle
+            try:
+                original_print(*args, **mirror_kwargs, flush=True)
+            except OSError:
+                tty_handle.close()
+                tty_handle = None
+
+    return console_print
+
+
+print = setup_console_print()
 
 
 def map_controller_to_key(code):

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
@@ -5,6 +5,9 @@ import os
 import time
 
 CONFIG_FILE = "/storage/.config/emuelec/scripts/macro_config.json"
+MAX_NAME_LEN = 16
+NAME_ALPHABET = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_")
+
 
 def map_controller_to_key(code):
     mapping = {
@@ -19,13 +22,51 @@ def map_controller_to_key(code):
     }
     return mapping.get(code)
 
+
+def ensure_config_dir():
+    os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
+
+
+def load_config():
+    if not os.path.exists(CONFIG_FILE):
+        return {"macros": []}
+
+    with open(CONFIG_FILE, "r") as f:
+        data = json.load(f)
+
+    # migrate old single-macro configuration
+    if "macros" not in data:
+        macro = {
+            "name": "DEFAULT MACRO",
+            "trigger_code": data.get("trigger_code"),
+            "macro_keys": data.get("macro_keys", []),
+        }
+        return {
+            "device_path": data.get("device_path"),
+            "macros": [macro],
+        }
+
+    return data
+
+
 def save_config(data):
+    ensure_config_dir()
     with open(CONFIG_FILE, "w") as f:
-        json.dump(data, f)
+        json.dump(data, f, indent=2)
     print(f"\n✅ Configuration saved to {CONFIG_FILE}.")
 
-def wait_for_controller():
+
+def wait_for_controller(preferred_path=None):
     print("\n🔌 Waiting for controller...")
+
+    if preferred_path:
+        try:
+            dev = InputDevice(preferred_path)
+            print(f"🎮 Controller found: {dev.name} ({dev.path})")
+            return dev
+        except OSError:
+            pass
+
     while True:
         devices = [InputDevice(path) for path in list_devices()]
         for dev in devices:
@@ -36,15 +77,117 @@ def wait_for_controller():
                     return dev
         time.sleep(1)
 
+
+def clear_console():
+    print("\033c", end="")
+
+
+def controller_menu(dev, title, options, allow_cancel=False):
+    index = 0 if options else -1
+
+    while True:
+        clear_console()
+        print(title)
+        print("\nUse D-Pad to choose and press (A) to confirm." )
+        if allow_cancel:
+            print("Press (B) to cancel.")
+        print()
+
+        for i, option in enumerate(options):
+            prefix = "👉" if i == index else "  "
+            print(f"{prefix} {option}")
+
+        if not options:
+            print("\nNo options available.")
+
+        for event in dev.read_loop():
+            if event.type != e.EV_KEY or event.value != 1:
+                continue
+
+            if event.code == e.BTN_DPAD_DOWN and options:
+                index = (index + 1) % len(options)
+                break
+            if event.code == e.BTN_DPAD_UP and options:
+                index = (index - 1) % len(options)
+                break
+            if event.code == e.BTN_SOUTH and options:
+                return index
+            if allow_cancel and event.code == e.BTN_EAST:
+                return None
+
+        # loop will refresh display after handling navigation
+
+
+def enter_macro_name(dev, default_name):
+    name = list(default_name.upper()[:MAX_NAME_LEN])
+    if not name:
+        name = list("MACRO")
+
+    while len(name) < MAX_NAME_LEN:
+        name.append(" ")
+
+    position = 0
+
+    while True:
+        clear_console()
+        print("✏️  Name your macro")
+        print("\nUse LEFT/RIGHT to move, UP/DOWN to change character.")
+        print("Press (A) to accept, (Y) to erase character, (B) to cancel.")
+        print()
+
+        display = []
+        for idx, char in enumerate(name):
+            if idx == position:
+                display.append(f"[{char}]")
+            else:
+                display.append(f" {char} ")
+        print("".join(display))
+
+        for event in dev.read_loop():
+            if event.type != e.EV_KEY or event.value != 1:
+                continue
+
+            if event.code == e.BTN_DPAD_RIGHT:
+                position = min(position + 1, MAX_NAME_LEN - 1)
+                break
+            if event.code == e.BTN_DPAD_LEFT:
+                position = max(position - 1, 0)
+                break
+            if event.code == e.BTN_DPAD_UP:
+                current = name[position]
+                try:
+                    idx = NAME_ALPHABET.index(current)
+                except ValueError:
+                    idx = 0
+                name[position] = NAME_ALPHABET[(idx + 1) % len(NAME_ALPHABET)]
+                break
+            if event.code == e.BTN_DPAD_DOWN:
+                current = name[position]
+                try:
+                    idx = NAME_ALPHABET.index(current)
+                except ValueError:
+                    idx = 0
+                name[position] = NAME_ALPHABET[(idx - 1) % len(NAME_ALPHABET)]
+                break
+            if event.code == e.BTN_WEST:  # Y button to clear character
+                name[position] = " "
+                break
+            if event.code == e.BTN_SOUTH:
+                final_name = "".join(name).strip()
+                return final_name or default_name.upper()
+            if event.code == e.BTN_EAST:
+                return None
+
+
 def record_trigger_button(dev):
     print("\n🎯 Press the button that will later trigger the macro...")
     while True:
         for event in dev.read_loop():
-            if event.type == e.EV_KEY and event.value == 1:
-                if event.code != e.BTN_MODE:
-                    print(f"Trigger button: Code {event.code}")
-                    time.sleep(0.5)
-                    return event.code
+            if event.type == e.EV_KEY and event.value == 1 and event.code != e.BTN_MODE:
+                print(f"Trigger button: Code {event.code}")
+                time.sleep(0.5)
+                return event.code
+
 
 def record_macro_sequence(dev, trigger_code):
     print("\n⌨ Press the buttons for your macro (recording ends after a 3-second pause)...")
@@ -65,22 +208,61 @@ def record_macro_sequence(dev, trigger_code):
         return None
 
     mapped = [map_controller_to_key(c) for c in macro_keys if map_controller_to_key(c)]
+    if not mapped:
+        print("❌ None of the recorded buttons can be mapped to keyboard keys!")
+        return None
+
     print(f"🎬 Macro recorded: {len(mapped)} valid keys")
     return mapped
 
+
 def main():
-    dev = wait_for_controller()
+    config = load_config()
+    dev = wait_for_controller(config.get("device_path"))
+
+    macros = config.setdefault("macros", [])
+    options = [f"Overwrite: {macro['name']}" for macro in macros]
+    options.append("Create new macro")
+
+    selection = controller_menu(dev, "🎛  Choose macro slot", options, allow_cancel=True)
+    if selection is None:
+        print("\n❌ Setup cancelled.")
+        return
+
+    creating_new = selection == len(macros)
+
+    if creating_new:
+        default_name = f"MACRO {len(macros) + 1}"
+        macro_name = enter_macro_name(dev, default_name)
+        if macro_name is None:
+            print("\n❌ Setup cancelled.")
+            return
+    else:
+        macro_name = macros[selection]["name"]
+        print(f"\n⚠️  Overwriting macro '{macro_name}'. Press the trigger to re-record.")
+
     trigger_code = record_trigger_button(dev)
     macro_keys = record_macro_sequence(dev, trigger_code)
 
     if macro_keys:
-        save_config({
-            "device_path": dev.path,
+        new_macro = {
+            "name": macro_name,
             "trigger_code": trigger_code,
-            "macro_keys": macro_keys
-        })
+            "macro_keys": macro_keys,
+        }
+
+        if creating_new:
+            macros.append(new_macro)
+        else:
+            macros[selection] = new_macro
+
+        config["device_path"] = dev.path
+        save_config(config)
         print("\n✅ Setup complete! Start the macro later with:")
         print("python3 macrorun.py")
+    else:
+        print("\n❌ Macro recording aborted.")
+
 
 if __name__ == "__main__":
     main()

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
@@ -6,6 +6,7 @@ import stat
 import time
 import builtins
 import sys
+from typing import Optional
 
 CONFIG_FILE = "/storage/.config/emuelec/scripts/macro_config.json"
 MAX_NAME_LEN = 16
@@ -20,19 +21,31 @@ NAME_ALPHABET = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_")
 
 
 class ConsoleMirror:
-    def __init__(self, original_print):
-        self._print = original_print
-        self._handle = None
-        self._path = None
-        self._candidates = ("/tmp/display", "/dev/tty0", "/dev/console")
+    """Mirror stdout to the active framebuffer console.
 
-    def _open_candidate(self, path):
+    EmuELEC exposes the console via a FIFO at /tmp/display while a couple of
+    devices rely on direct writes to /dev/tty* nodes.  We lazily try each
+    candidate, reopen on failures and write through using os.write so ANSI
+    sequences (e.g. from clear_console) are preserved exactly as emitted.
+    """
+
+    def __init__(self):
+        self._fd: Optional[int] = None
+        self._path: Optional[str] = None
+        self._candidates = (
+            "/tmp/display",
+            "/dev/tty1",
+            "/dev/tty0",
+            "/dev/console",
+        )
+
+    def _open_candidate(self, path: str) -> Optional[int]:
         try:
             mode = os.stat(path).st_mode
         except OSError:
             return None
 
-        flags = os.O_WRONLY
+        flags = os.O_WRONLY | os.O_CLOEXEC
         if stat.S_ISFIFO(mode):
             flags |= os.O_NONBLOCK
 
@@ -41,62 +54,65 @@ class ConsoleMirror:
         except OSError:
             return None
 
-        try:
-            handle = os.fdopen(fd, "w", buffering=1, encoding="utf-8", errors="replace")
-        except OSError:
-            os.close(fd)
-            return None
+        return fd
 
-        return handle
-
-    def _ensure_handle(self):
-        if self._handle:
+    def _ensure_fd(self) -> bool:
+        if self._fd is not None:
             return True
 
         for path in self._candidates:
-            handle = self._open_candidate(path)
-            if handle:
-                self._handle = handle
+            fd = self._open_candidate(path)
+            if fd is not None:
+                self._fd = fd
                 self._path = path
                 return True
         return False
 
-    def _close_handle(self):
-        if not self._handle:
+    def _close_fd(self) -> None:
+        if self._fd is None:
             return
+
         try:
-            self._handle.close()
+            os.close(self._fd)
         except OSError:
             pass
-        self._handle = None
+        self._fd = None
         self._path = None
 
-    def print(self, *args, **kwargs):
-        target = kwargs.get("file", sys.stdout)
-        kwargs.pop("flush", None)
-        self._print(*args, **kwargs, flush=True)
-
-        if target not in (None, sys.stdout):
+    def write(self, text: str) -> None:
+        if not text:
             return
 
-        if not self._ensure_handle():
+        if not self._ensure_fd():
             return
 
-        mirror_kwargs = dict(kwargs)
-        mirror_kwargs["file"] = self._handle
+        data = text.encode("utf-8", "replace")
         try:
-            self._print(*args, **mirror_kwargs, flush=True)
+            os.write(self._fd, data)
         except OSError:
-            self._close_handle()
+            self._close_fd()
+
+
+class PrintWrapper:
+    def __init__(self, original_print):
+        self._print = original_print
+        self._mirror = ConsoleMirror()
+
+    def __call__(self, *args, **kwargs):
+        target = kwargs.get("file", sys.stdout)
+        sep = kwargs.get("sep", " ")
+        end = kwargs.get("end", "\n")
+
+        text = sep.join(str(arg) for arg in args) + end
+        kwargs["flush"] = True
+        self._print(*args, **kwargs)
+
+        if target in (None, sys.stdout):
+            self._mirror.write(text)
 
 
 def setup_console_print():
-    mirror = ConsoleMirror(builtins.print)
-
-    def console_print(*args, **kwargs):
-        mirror.print(*args, **kwargs)
-
-    return console_print
+    return PrintWrapper(builtins.print)
 
 
 if hasattr(sys.stdout, "reconfigure"):

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
@@ -30,6 +30,7 @@ def setup_console_print():
             continue
 
     def console_print(*args, **kwargs):
+        nonlocal tty_handle
         target = kwargs.get("file", sys.stdout)
         kwargs.pop("flush", None)
         original_print(*args, **kwargs, flush=True)

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
@@ -3,10 +3,16 @@ from evdev import InputDevice, list_devices, ecodes as e
 import json
 import os
 import time
+import builtins
+from functools import partial
 
 CONFIG_FILE = "/storage/.config/emuelec/scripts/macro_config.json"
 MAX_NAME_LEN = 16
 NAME_ALPHABET = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_")
+
+# Ensure everything printed by the script is flushed immediately so it appears
+# on the on-device console.
+print = partial(builtins.print, flush=True)
 
 
 def map_controller_to_key(code):
@@ -19,6 +25,10 @@ def map_controller_to_key(code):
         e.BTN_EAST: e.KEY_X,
         e.BTN_NORTH: e.KEY_A,
         e.BTN_WEST: e.KEY_S,
+        e.BTN_TL: e.KEY_Q,
+        e.BTN_TR: e.KEY_W,
+        e.BTN_TL2: e.KEY_E,
+        e.BTN_TR2: e.KEY_R,
     }
     return mapping.get(code)
 
@@ -79,7 +89,7 @@ def wait_for_controller(preferred_path=None):
 
 
 def clear_console():
-    print("\033c", end="")
+    print("\033[2J\033[H", end="")
 
 
 def controller_menu(dev, title, options, allow_cancel=False):

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
@@ -2,6 +2,7 @@
 from evdev import InputDevice, list_devices, ecodes as e
 import json
 import os
+import stat
 import time
 import builtins
 import sys
@@ -13,38 +14,96 @@ NAME_ALPHABET = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_")
 # Ensure everything printed by the script is flushed immediately so it appears
 # on the on-device console. When executed from the EmulationStation UI the
 # script's stdout is piped through tee, which prevents text from reaching the
-# TV unless we also write directly to the active framebuffer console.  We keep
+# TV unless we also write directly to the active console device.  We keep
 # logging through stdout (for /tmp/macrosetup.log) while mirroring all messages
-# to /dev/tty0 (or /dev/console as a fallback).
+# to /tmp/display (preferred) or /dev/tty0 / /dev/console as fallbacks.
+
+
+class ConsoleMirror:
+    def __init__(self, original_print):
+        self._print = original_print
+        self._handle = None
+        self._path = None
+        self._candidates = ("/tmp/display", "/dev/tty0", "/dev/console")
+
+    def _open_candidate(self, path):
+        try:
+            mode = os.stat(path).st_mode
+        except OSError:
+            return None
+
+        flags = os.O_WRONLY
+        if stat.S_ISFIFO(mode):
+            flags |= os.O_NONBLOCK
+
+        try:
+            fd = os.open(path, flags)
+        except OSError:
+            return None
+
+        try:
+            handle = os.fdopen(fd, "w", buffering=1, encoding="utf-8", errors="replace")
+        except OSError:
+            os.close(fd)
+            return None
+
+        return handle
+
+    def _ensure_handle(self):
+        if self._handle:
+            return True
+
+        for path in self._candidates:
+            handle = self._open_candidate(path)
+            if handle:
+                self._handle = handle
+                self._path = path
+                return True
+        return False
+
+    def _close_handle(self):
+        if not self._handle:
+            return
+        try:
+            self._handle.close()
+        except OSError:
+            pass
+        self._handle = None
+        self._path = None
+
+    def print(self, *args, **kwargs):
+        target = kwargs.get("file", sys.stdout)
+        kwargs.pop("flush", None)
+        self._print(*args, **kwargs, flush=True)
+
+        if target not in (None, sys.stdout):
+            return
+
+        if not self._ensure_handle():
+            return
+
+        mirror_kwargs = dict(kwargs)
+        mirror_kwargs["file"] = self._handle
+        try:
+            self._print(*args, **mirror_kwargs, flush=True)
+        except OSError:
+            self._close_handle()
 
 
 def setup_console_print():
-    original_print = builtins.print
-    tty_handle = None
-
-    for path in ("/dev/tty0", "/dev/console"):
-        try:
-            tty_handle = open(path, "w", buffering=1)
-            break
-        except OSError:
-            continue
+    mirror = ConsoleMirror(builtins.print)
 
     def console_print(*args, **kwargs):
-        nonlocal tty_handle
-        target = kwargs.get("file", sys.stdout)
-        kwargs.pop("flush", None)
-        original_print(*args, **kwargs, flush=True)
-
-        if tty_handle and target in (None, sys.stdout):
-            mirror_kwargs = dict(kwargs)
-            mirror_kwargs["file"] = tty_handle
-            try:
-                original_print(*args, **mirror_kwargs, flush=True)
-            except OSError:
-                tty_handle.close()
-                tty_handle = None
+        mirror.print(*args, **kwargs)
 
     return console_print
+
+
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(line_buffering=True, write_through=True)
+    except (ValueError, OSError):
+        pass
 
 
 print = setup_console_print()

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
@@ -3,8 +3,8 @@ from evdev import InputDevice, list_devices, ecodes as e
 import json
 import os
 import time
+import atexit
 import builtins
-import functools
 import sys
 
 CONFIG_FILE = "/storage/.config/emuelec/scripts/macro_config.json"
@@ -17,9 +17,95 @@ if hasattr(sys.stdout, "reconfigure"):
     except (ValueError, OSError):
         pass
 
-# Every print call should flush immediately so prompts appear on the EmuELEC
-# console even when the script runs through a tee pipeline.
-print = functools.partial(builtins.print, flush=True)
+
+class ConsoleMirror:
+    """Mirror stdout to the active EmuELEC console if available."""
+
+    def __init__(self):
+        self._fd = None
+        self._candidates = [
+            "/tmp/display",
+            "/dev/tty0",
+            "/dev/tty1",
+            "/dev/console",
+        ]
+
+    def _open_target(self):
+        if self._fd is not None:
+            return True
+
+        for path in self._candidates:
+            try:
+                fd = os.open(path, os.O_WRONLY | os.O_NONBLOCK)
+            except OSError:
+                continue
+
+            self._fd = fd
+            return True
+
+        return False
+
+    def write(self, text):
+        if not text:
+            return
+
+        data = text.encode("utf-8", "replace")
+
+        if self._fd is None and not self._open_target():
+            return
+
+        try:
+            os.write(self._fd, data)
+        except OSError:
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+            finally:
+                self._fd = None
+
+            # Retry once with a fresh handle. If it fails again we give up.
+            if self._open_target():
+                try:
+                    os.write(self._fd, data)
+                except OSError:
+                    pass
+
+    def close(self):
+        if self._fd is not None:
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+            finally:
+                self._fd = None
+
+
+_builtin_print = builtins.print
+_console_mirror = ConsoleMirror()
+atexit.register(_console_mirror.close)
+
+
+def console_print(*args, **kwargs):
+    file = kwargs.get("file", sys.stdout)
+    sep = kwargs.get("sep", " ")
+    end = kwargs.get("end", "\n")
+
+    if file is sys.stdout or file is None:
+        if not args:
+            mirrored = end
+        else:
+            mirrored = sep.join(str(arg) for arg in args) + end
+
+        _console_mirror.write(mirrored)
+
+        kwargs = dict(kwargs)
+        kwargs["flush"] = True
+
+    _builtin_print(*args, **kwargs)
+
+
+print = console_print
 
 
 def map_controller_to_key(code):

--- a/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
+++ b/packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py
@@ -2,118 +2,14 @@
 from evdev import InputDevice, list_devices, ecodes as e
 import json
 import os
-import stat
 import time
 import builtins
+import functools
 import sys
-from typing import Optional
 
 CONFIG_FILE = "/storage/.config/emuelec/scripts/macro_config.json"
 MAX_NAME_LEN = 16
 NAME_ALPHABET = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_")
-
-# Ensure everything printed by the script is flushed immediately so it appears
-# on the on-device console. When executed from the EmulationStation UI the
-# script's stdout is piped through tee, which prevents text from reaching the
-# TV unless we also write directly to the active console device.  We keep
-# logging through stdout (for /tmp/macrosetup.log) while mirroring all messages
-# to /tmp/display (preferred) or /dev/tty0 / /dev/console as fallbacks.
-
-
-class ConsoleMirror:
-    """Mirror stdout to the active framebuffer console.
-
-    EmuELEC exposes the console via a FIFO at /tmp/display while a couple of
-    devices rely on direct writes to /dev/tty* nodes.  We lazily try each
-    candidate, reopen on failures and write through using os.write so ANSI
-    sequences (e.g. from clear_console) are preserved exactly as emitted.
-    """
-
-    def __init__(self):
-        self._fd: Optional[int] = None
-        self._path: Optional[str] = None
-        self._candidates = (
-            "/tmp/display",
-            "/dev/tty1",
-            "/dev/tty0",
-            "/dev/console",
-        )
-
-    def _open_candidate(self, path: str) -> Optional[int]:
-        try:
-            mode = os.stat(path).st_mode
-        except OSError:
-            return None
-
-        flags = os.O_WRONLY | os.O_CLOEXEC
-        if stat.S_ISFIFO(mode):
-            flags |= os.O_NONBLOCK
-
-        try:
-            fd = os.open(path, flags)
-        except OSError:
-            return None
-
-        return fd
-
-    def _ensure_fd(self) -> bool:
-        if self._fd is not None:
-            return True
-
-        for path in self._candidates:
-            fd = self._open_candidate(path)
-            if fd is not None:
-                self._fd = fd
-                self._path = path
-                return True
-        return False
-
-    def _close_fd(self) -> None:
-        if self._fd is None:
-            return
-
-        try:
-            os.close(self._fd)
-        except OSError:
-            pass
-        self._fd = None
-        self._path = None
-
-    def write(self, text: str) -> None:
-        if not text:
-            return
-
-        if not self._ensure_fd():
-            return
-
-        data = text.encode("utf-8", "replace")
-        try:
-            os.write(self._fd, data)
-        except OSError:
-            self._close_fd()
-
-
-class PrintWrapper:
-    def __init__(self, original_print):
-        self._print = original_print
-        self._mirror = ConsoleMirror()
-
-    def __call__(self, *args, **kwargs):
-        target = kwargs.get("file", sys.stdout)
-        sep = kwargs.get("sep", " ")
-        end = kwargs.get("end", "\n")
-
-        text = sep.join(str(arg) for arg in args) + end
-        kwargs["flush"] = True
-        self._print(*args, **kwargs)
-
-        if target in (None, sys.stdout):
-            self._mirror.write(text)
-
-
-def setup_console_print():
-    return PrintWrapper(builtins.print)
-
 
 if hasattr(sys.stdout, "reconfigure"):
     try:
@@ -121,8 +17,9 @@ if hasattr(sys.stdout, "reconfigure"):
     except (ValueError, OSError):
         pass
 
-
-print = setup_console_print()
+# Every print call should flush immediately so prompts appear on the EmuELEC
+# console even when the script runs through a tee pipeline.
+print = functools.partial(builtins.print, flush=True)
 
 
 def map_controller_to_key(code):


### PR DESCRIPTION
## Summary
- allow macro setup to store multiple controller-driven macros with on-device naming
- provide controller-only menus to create, overwrite, and select macros without a keyboard
- update macro runner to choose a saved macro before activation while keeping legacy configs compatible

## Testing
- python3 -m py_compile packages/sx05re/emuelec/bin/scripts/setup/macrosetup.py packages/sx05re/emuelec/bin/scripts/setup/macrorun.py

------
https://chatgpt.com/codex/tasks/task_e_68ef6051ff648320be1fb82df2969dd6